### PR TITLE
"Improve" metadata class by making it simpler

### DIFF
--- a/Tutorial_irodsConnector.ipynb
+++ b/Tutorial_irodsConnector.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "b6fd51d6",
    "metadata": {},
    "outputs": [],
@@ -38,18 +38,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "cf36ab7b",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Auth with password\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "with open(os.path.expanduser(\"~/.irods/irods_environment.json\"), \"r\") as f:\n",
     "    ienv = json.load(f)\n",
@@ -69,55 +61,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "242eab2c",
    "metadata": {
     "hidden": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Auth with password\n"
-     ]
-    },
-    {
-     "ename": "TypeError",
-     "evalue": "expected string or bytes-like object, got 'NoneType'",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mSyntaxError\u001b[0m                               Traceback (most recent call last)",
-      "File \u001b[0;32m~/.pyenv/versions/3.11.5/lib/python3.11/site-packages/irods/session.py:215\u001b[0m, in \u001b[0;36miRODSSession.server_version\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    214\u001b[0m     reported_vsn \u001b[39m=\u001b[39m os\u001b[39m.\u001b[39menviron\u001b[39m.\u001b[39mget(\u001b[39m\"\u001b[39m\u001b[39mPYTHON_IRODSCLIENT_REPORTED_SERVER_VERSION\u001b[39m\u001b[39m\"\u001b[39m,\u001b[39m\"\u001b[39m\u001b[39m\"\u001b[39m)\n\u001b[0;32m--> 215\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mtuple\u001b[39m(ast\u001b[39m.\u001b[39;49mliteral_eval(reported_vsn))\n\u001b[1;32m    216\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mSyntaxError\u001b[39;00m:  \u001b[39m# environment variable was malformed, empty, or unset\u001b[39;00m\n",
-      "File \u001b[0;32m~/.pyenv/versions/3.11.5/lib/python3.11/ast.py:64\u001b[0m, in \u001b[0;36mliteral_eval\u001b[0;34m(node_or_string)\u001b[0m\n\u001b[1;32m     63\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39misinstance\u001b[39m(node_or_string, \u001b[39mstr\u001b[39m):\n\u001b[0;32m---> 64\u001b[0m     node_or_string \u001b[39m=\u001b[39m parse(node_or_string\u001b[39m.\u001b[39;49mlstrip(\u001b[39m\"\u001b[39;49m\u001b[39m \u001b[39;49m\u001b[39m\\t\u001b[39;49;00m\u001b[39m\"\u001b[39;49m), mode\u001b[39m=\u001b[39;49m\u001b[39m'\u001b[39;49m\u001b[39meval\u001b[39;49m\u001b[39m'\u001b[39;49m)\n\u001b[1;32m     65\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39misinstance\u001b[39m(node_or_string, Expression):\n",
-      "File \u001b[0;32m~/.pyenv/versions/3.11.5/lib/python3.11/ast.py:50\u001b[0m, in \u001b[0;36mparse\u001b[0;34m(source, filename, mode, type_comments, feature_version)\u001b[0m\n\u001b[1;32m     49\u001b[0m \u001b[39m# Else it should be an int giving the minor version for 3.x.\u001b[39;00m\n\u001b[0;32m---> 50\u001b[0m \u001b[39mreturn\u001b[39;00m \u001b[39mcompile\u001b[39m(source, filename, mode, flags,\n\u001b[1;32m     51\u001b[0m                _feature_version\u001b[39m=\u001b[39mfeature_version)\n",
-      "\u001b[0;31mSyntaxError\u001b[0m: invalid syntax (<unknown>, line 0)",
-      "\nDuring handling of the above exception, another exception occurred:\n",
-      "\u001b[0;31mStopIteration\u001b[0m                             Traceback (most recent call last)",
-      "File \u001b[0;32m~/.pyenv/versions/3.11.5/lib/python3.11/site-packages/irods/session.py:221\u001b[0m, in \u001b[0;36miRODSSession.__server_version\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    220\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 221\u001b[0m     conn \u001b[39m=\u001b[39m \u001b[39mnext\u001b[39;49m(\u001b[39miter\u001b[39;49m(\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mpool\u001b[39m.\u001b[39;49mactive))\n\u001b[1;32m    222\u001b[0m     \u001b[39mreturn\u001b[39;00m conn\u001b[39m.\u001b[39mserver_version\n",
-      "\u001b[0;31mStopIteration\u001b[0m: ",
-      "\nDuring handling of the above exception, another exception occurred:\n",
-      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
-      "File \u001b[0;32m~/.pyenv/versions/3.11.5/lib/python3.11/site-packages/irods/pool.py:59\u001b[0m, in \u001b[0;36mPool.get_connection\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     58\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m---> 59\u001b[0m     conn \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49midle\u001b[39m.\u001b[39;49mpop()\n\u001b[1;32m     61\u001b[0m     curr_time \u001b[39m=\u001b[39m datetime\u001b[39m.\u001b[39mdatetime\u001b[39m.\u001b[39mnow()\n",
-      "\u001b[0;31mKeyError\u001b[0m: 'pop from an empty set'",
-      "\nDuring handling of the above exception, another exception occurred:\n",
-      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
-      "\u001b[1;32m/home/qubix/Documents/shared_work/iBridges/Tutorial_irodsConnector.ipynb Cell 7\u001b[0m line \u001b[0;36m1\n\u001b[0;32m----> <a href='vscode-notebook-cell:/home/qubix/Documents/shared_work/iBridges/Tutorial_irodsConnector.ipynb#W6sZmlsZQ%3D%3D?line=0'>1</a>\u001b[0m session \u001b[39m=\u001b[39m Session(irods_env_path\u001b[39m=\u001b[39;49mos\u001b[39m.\u001b[39;49mpath\u001b[39m.\u001b[39;49mexpanduser(\u001b[39m\"\u001b[39;49m\u001b[39m~/.irods/irods_environment.json\u001b[39;49m\u001b[39m\"\u001b[39;49m))\n",
-      "File \u001b[0;32m~/Documents/shared_work/iBridges/ibridges/irodsconnector/session.py:42\u001b[0m, in \u001b[0;36mSession.__init__\u001b[0;34m(self, irods_env, irods_env_path, password)\u001b[0m\n\u001b[1;32m     40\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_irods_env \u001b[39m=\u001b[39m irods_env\n\u001b[1;32m     41\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_irods_env_path \u001b[39m=\u001b[39m irods_env_path\n\u001b[0;32m---> 42\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_irods_session \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mconnect()\n",
-      "File \u001b[0;32m~/Documents/shared_work/iBridges/ibridges/irodsconnector/session.py:109\u001b[0m, in \u001b[0;36mSession.connect\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    107\u001b[0m \u001b[39mprint\u001b[39m(\u001b[39m\"\u001b[39m\u001b[39mAuth with password\u001b[39m\u001b[39m\"\u001b[39m)\n\u001b[1;32m    108\u001b[0m \u001b[39m# irods environment and given password\u001b[39;00m\n\u001b[0;32m--> 109\u001b[0m \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mauthenticate_using_password()\n",
-      "File \u001b[0;32m~/Documents/shared_work/iBridges/ibridges/irodsconnector/session.py:125\u001b[0m, in \u001b[0;36mSession.authenticate_using_password\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    123\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mException\u001b[39;00m(exceptions[\u001b[39mrepr\u001b[39m(e)]\u001b[39m+\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m; \u001b[39m\u001b[39m\"\u001b[39m\u001b[39m+\u001b[39m\u001b[39mrepr\u001b[39m(e))\n\u001b[1;32m    124\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[0;32m--> 125\u001b[0m     \u001b[39mraise\u001b[39;00m e\n",
-      "File \u001b[0;32m~/Documents/shared_work/iBridges/ibridges/irodsconnector/session.py:115\u001b[0m, in \u001b[0;36mSession.authenticate_using_password\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    112\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[1;32m    113\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_irods_session \u001b[39m=\u001b[39m irods\u001b[39m.\u001b[39msession\u001b[39m.\u001b[39miRODSSession(password\u001b[39m=\u001b[39m\u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_password,\n\u001b[1;32m    114\u001b[0m                                                      \u001b[39m*\u001b[39m\u001b[39m*\u001b[39m\u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_irods_env)\n\u001b[0;32m--> 115\u001b[0m     \u001b[39massert\u001b[39;00m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_irods_session\u001b[39m.\u001b[39;49mserver_version \u001b[39m!=\u001b[39m ()\n\u001b[1;32m    116\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_irods_session\n\u001b[1;32m    117\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mValueError\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n",
-      "File \u001b[0;32m~/.pyenv/versions/3.11.5/lib/python3.11/site-packages/irods/session.py:217\u001b[0m, in \u001b[0;36miRODSSession.server_version\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    215\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mtuple\u001b[39m(ast\u001b[39m.\u001b[39mliteral_eval(reported_vsn))\n\u001b[1;32m    216\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mSyntaxError\u001b[39;00m:  \u001b[39m# environment variable was malformed, empty, or unset\u001b[39;00m\n\u001b[0;32m--> 217\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m__server_version()\n",
-      "File \u001b[0;32m~/.pyenv/versions/3.11.5/lib/python3.11/site-packages/irods/session.py:224\u001b[0m, in \u001b[0;36miRODSSession.__server_version\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    222\u001b[0m     \u001b[39mreturn\u001b[39;00m conn\u001b[39m.\u001b[39mserver_version\n\u001b[1;32m    223\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mStopIteration\u001b[39;00m:\n\u001b[0;32m--> 224\u001b[0m     conn \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mpool\u001b[39m.\u001b[39;49mget_connection()\n\u001b[1;32m    225\u001b[0m     version \u001b[39m=\u001b[39m conn\u001b[39m.\u001b[39mserver_version\n\u001b[1;32m    226\u001b[0m     conn\u001b[39m.\u001b[39mrelease()\n",
-      "File \u001b[0;32m~/.pyenv/versions/3.11.5/lib/python3.11/site-packages/irods/pool.py:15\u001b[0m, in \u001b[0;36mattribute_from_return_value.<locals>.deco.<locals>.method_\u001b[0;34m(self, *s, **kw)\u001b[0m\n\u001b[1;32m     14\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mmethod_\u001b[39m(\u001b[39mself\u001b[39m,\u001b[39m*\u001b[39ms,\u001b[39m*\u001b[39m\u001b[39m*\u001b[39mkw):\n\u001b[0;32m---> 15\u001b[0m     ret \u001b[39m=\u001b[39m method(\u001b[39mself\u001b[39;49m,\u001b[39m*\u001b[39;49ms,\u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mkw)\n\u001b[1;32m     16\u001b[0m     \u001b[39msetattr\u001b[39m(\u001b[39mself\u001b[39m,attrname,ret)\n\u001b[1;32m     17\u001b[0m     \u001b[39mreturn\u001b[39;00m ret\n",
-      "File \u001b[0;32m~/.pyenv/versions/3.11.5/lib/python3.11/site-packages/irods/pool.py:75\u001b[0m, in \u001b[0;36mPool.get_connection\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     73\u001b[0m         logger\u001b[39m.\u001b[39mdebug(\u001b[39m\"\u001b[39m\u001b[39mCreated new connection with id: \u001b[39m\u001b[39m{}\u001b[39;00m\u001b[39m\"\u001b[39m\u001b[39m.\u001b[39mformat(\u001b[39mid\u001b[39m(conn)))\n\u001b[1;32m     74\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mKeyError\u001b[39;00m:\n\u001b[0;32m---> 75\u001b[0m     conn \u001b[39m=\u001b[39m Connection(\u001b[39mself\u001b[39;49m, \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49maccount)\n\u001b[1;32m     76\u001b[0m     logger\u001b[39m.\u001b[39mdebug(\u001b[39m\"\u001b[39m\u001b[39mNo connection found in idle set. Created a new connection with id: \u001b[39m\u001b[39m{}\u001b[39;00m\u001b[39m\"\u001b[39m\u001b[39m.\u001b[39mformat(\u001b[39mid\u001b[39m(conn)))\n\u001b[1;32m     78\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mactive\u001b[39m.\u001b[39madd(conn)\n",
-      "File \u001b[0;32m~/.pyenv/versions/3.11.5/lib/python3.11/site-packages/irods/connection.py:74\u001b[0m, in \u001b[0;36mConnection.__init__\u001b[0;34m(self, pool, account)\u001b[0m\n\u001b[1;32m     72\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_login_gsi()\n\u001b[1;32m     73\u001b[0m \u001b[39melif\u001b[39;00m scheme \u001b[39m==\u001b[39m PAM_AUTH_SCHEME:\n\u001b[0;32m---> 74\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_login_pam()\n\u001b[1;32m     75\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[1;32m     76\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mValueError\u001b[39;00m(\u001b[39m\"\u001b[39m\u001b[39mUnknown authentication scheme \u001b[39m\u001b[39m%s\u001b[39;00m\u001b[39m\"\u001b[39m \u001b[39m%\u001b[39m scheme)\n",
-      "File \u001b[0;32m~/.pyenv/versions/3.11.5/lib/python3.11/site-packages/irods/connection.py:443\u001b[0m, in \u001b[0;36mConnection._login_pam\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    439\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_login_pam\u001b[39m(\u001b[39mself\u001b[39m):\n\u001b[1;32m    441\u001b[0m     time_to_live_in_seconds \u001b[39m=\u001b[39m \u001b[39m60\u001b[39m\n\u001b[0;32m--> 443\u001b[0m     pam_password \u001b[39m=\u001b[39m PAM_PW_ESC_PATTERN\u001b[39m.\u001b[39;49msub(\u001b[39mlambda\u001b[39;49;00m m: \u001b[39m'\u001b[39;49m\u001b[39m\\\\\u001b[39;49;00m\u001b[39m'\u001b[39;49m\u001b[39m+\u001b[39;49mm\u001b[39m.\u001b[39;49mgroup(\u001b[39m1\u001b[39;49m), \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49maccount\u001b[39m.\u001b[39;49mpassword)\n\u001b[1;32m    445\u001b[0m     ctx_user \u001b[39m=\u001b[39m \u001b[39m'\u001b[39m\u001b[39m%s\u001b[39;00m\u001b[39m=\u001b[39m\u001b[39m%s\u001b[39;00m\u001b[39m'\u001b[39m \u001b[39m%\u001b[39m (AUTH_USER_KEY, \u001b[39mself\u001b[39m\u001b[39m.\u001b[39maccount\u001b[39m.\u001b[39mclient_user)\n\u001b[1;32m    446\u001b[0m     ctx_pwd \u001b[39m=\u001b[39m \u001b[39m'\u001b[39m\u001b[39m%s\u001b[39;00m\u001b[39m=\u001b[39m\u001b[39m%s\u001b[39;00m\u001b[39m'\u001b[39m \u001b[39m%\u001b[39m (AUTH_PWD_KEY, pam_password)\n",
-      "\u001b[0;31mTypeError\u001b[0m: expected string or bytes-like object, got 'NoneType'"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "session = Session(irods_env_path=os.path.expanduser(\"~/.irods/irods_environment.json\"))"
    ]
@@ -132,21 +81,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "fe178d2c",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "r.d.schram@uu.nl\n",
-      "irodsResc\n",
-      "nluu12p\n",
-      "(4, 2, 12)\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(session.username)\n",
     "print(session.default_resc) # the resource to which data will be uploaded\n",
@@ -165,18 +103,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "9ae7d602",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "/nluu12p/home/research-test-christine/books/BenHur.txt\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "#print(ienv)\n",
     "coll_path = ienv.get('irods_home', '') + '/books/BenHur.txt'\n",
@@ -186,21 +116,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "2e8f3c90",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " - {name: AUTHOR, value: Lew Wallace, units: None}\n",
-      " - {name: HUHU, value: hihi, units: None}\n",
-      " - {name: NEWKEY, value: hihi, units: None}\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from ibridges.irodsconnector.meta import MetaData\n",
     "coll_meta = MetaData(coll)\n",
@@ -217,22 +136,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "cfa7f559",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " - {name: AUTHOR, value: Lew Wallace, units: None}\n",
-      " - {name: NEWKEY, value: NewValue, units: None}\n",
-      " - {name: HUHU, value: hihi, units: None}\n",
-      " - {name: NEWKEY, value: hihi, units: None}\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "coll_meta.add('NewKey', 'NewValue')\n",
     "print(coll_meta)"
@@ -248,21 +155,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "d8aa144a",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      " - {name: AUTHOR, value: Lew Wallace, units: None}\n",
-      " - {name: HUHU, value: hihi, units: None}\n",
-      " - {name: NEWKEY, value: hihi, units: None}\n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "coll_meta.delete('NEWKEY', 'NewValue')\n",
     "print(coll_meta)"
@@ -283,7 +179,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "coll_meta.set(\"NEWKEY\", \"OtherValue\")"
+    "coll_meta.set(\"NEWKEY\", \"OtherValue\")\n",
+    "print(coll_meta)"
    ]
   },
   {

--- a/Tutorial_irodsConnector.ipynb
+++ b/Tutorial_irodsConnector.ipynb
@@ -131,7 +131,7 @@
    "id": "42007e1e",
    "metadata": {},
    "source": [
-    "### Add, set and delete metadata"
+    "### View, add, set and delete metadata"
    ]
   },
   {
@@ -142,6 +142,7 @@
    "outputs": [],
    "source": [
     "coll_meta.add('NewKey', 'NewValue')\n",
+    "coll_meta.add('NewKey', 'AnotherValue')\n",
     "print(coll_meta)"
    ]
   },
@@ -179,8 +180,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "coll_meta.set(\"NEWKEY\", \"OtherValue\")\n",
+    "coll_meta.set(\"NEWKEY\", \"YetAnotherValue\")\n",
     "print(coll_meta)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c3466265",
+   "metadata": {},
+   "source": [
+    "### Accessing metadata \n",
+    "With the orint function you can quickly inspect the metadata of an iRODS collection or object. If you want to extract and do something with the metadata, use the `__iter__` function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "eed12200",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for md in coll_meta.__iter__():\n",
+    "    if md.name == 'AUTHOR':\n",
+    "        print(coll_meta.item, \"was written by\", md.value)"
    ]
   },
   {
@@ -369,7 +391,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/Tutorial_irodsConnector.ipynb
+++ b/Tutorial_irodsConnector.ipynb
@@ -46,7 +46,6 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Your iRODS password········\n",
       "Auth with password\n"
      ]
     }
@@ -70,12 +69,55 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "242eab2c",
    "metadata": {
     "hidden": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Auth with password\n"
+     ]
+    },
+    {
+     "ename": "TypeError",
+     "evalue": "expected string or bytes-like object, got 'NoneType'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mSyntaxError\u001b[0m                               Traceback (most recent call last)",
+      "File \u001b[0;32m~/.pyenv/versions/3.11.5/lib/python3.11/site-packages/irods/session.py:215\u001b[0m, in \u001b[0;36miRODSSession.server_version\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    214\u001b[0m     reported_vsn \u001b[39m=\u001b[39m os\u001b[39m.\u001b[39menviron\u001b[39m.\u001b[39mget(\u001b[39m\"\u001b[39m\u001b[39mPYTHON_IRODSCLIENT_REPORTED_SERVER_VERSION\u001b[39m\u001b[39m\"\u001b[39m,\u001b[39m\"\u001b[39m\u001b[39m\"\u001b[39m)\n\u001b[0;32m--> 215\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mtuple\u001b[39m(ast\u001b[39m.\u001b[39;49mliteral_eval(reported_vsn))\n\u001b[1;32m    216\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mSyntaxError\u001b[39;00m:  \u001b[39m# environment variable was malformed, empty, or unset\u001b[39;00m\n",
+      "File \u001b[0;32m~/.pyenv/versions/3.11.5/lib/python3.11/ast.py:64\u001b[0m, in \u001b[0;36mliteral_eval\u001b[0;34m(node_or_string)\u001b[0m\n\u001b[1;32m     63\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39misinstance\u001b[39m(node_or_string, \u001b[39mstr\u001b[39m):\n\u001b[0;32m---> 64\u001b[0m     node_or_string \u001b[39m=\u001b[39m parse(node_or_string\u001b[39m.\u001b[39;49mlstrip(\u001b[39m\"\u001b[39;49m\u001b[39m \u001b[39;49m\u001b[39m\\t\u001b[39;49;00m\u001b[39m\"\u001b[39;49m), mode\u001b[39m=\u001b[39;49m\u001b[39m'\u001b[39;49m\u001b[39meval\u001b[39;49m\u001b[39m'\u001b[39;49m)\n\u001b[1;32m     65\u001b[0m \u001b[39mif\u001b[39;00m \u001b[39misinstance\u001b[39m(node_or_string, Expression):\n",
+      "File \u001b[0;32m~/.pyenv/versions/3.11.5/lib/python3.11/ast.py:50\u001b[0m, in \u001b[0;36mparse\u001b[0;34m(source, filename, mode, type_comments, feature_version)\u001b[0m\n\u001b[1;32m     49\u001b[0m \u001b[39m# Else it should be an int giving the minor version for 3.x.\u001b[39;00m\n\u001b[0;32m---> 50\u001b[0m \u001b[39mreturn\u001b[39;00m \u001b[39mcompile\u001b[39m(source, filename, mode, flags,\n\u001b[1;32m     51\u001b[0m                _feature_version\u001b[39m=\u001b[39mfeature_version)\n",
+      "\u001b[0;31mSyntaxError\u001b[0m: invalid syntax (<unknown>, line 0)",
+      "\nDuring handling of the above exception, another exception occurred:\n",
+      "\u001b[0;31mStopIteration\u001b[0m                             Traceback (most recent call last)",
+      "File \u001b[0;32m~/.pyenv/versions/3.11.5/lib/python3.11/site-packages/irods/session.py:221\u001b[0m, in \u001b[0;36miRODSSession.__server_version\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    220\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m--> 221\u001b[0m     conn \u001b[39m=\u001b[39m \u001b[39mnext\u001b[39;49m(\u001b[39miter\u001b[39;49m(\u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mpool\u001b[39m.\u001b[39;49mactive))\n\u001b[1;32m    222\u001b[0m     \u001b[39mreturn\u001b[39;00m conn\u001b[39m.\u001b[39mserver_version\n",
+      "\u001b[0;31mStopIteration\u001b[0m: ",
+      "\nDuring handling of the above exception, another exception occurred:\n",
+      "\u001b[0;31mKeyError\u001b[0m                                  Traceback (most recent call last)",
+      "File \u001b[0;32m~/.pyenv/versions/3.11.5/lib/python3.11/site-packages/irods/pool.py:59\u001b[0m, in \u001b[0;36mPool.get_connection\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     58\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[0;32m---> 59\u001b[0m     conn \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49midle\u001b[39m.\u001b[39;49mpop()\n\u001b[1;32m     61\u001b[0m     curr_time \u001b[39m=\u001b[39m datetime\u001b[39m.\u001b[39mdatetime\u001b[39m.\u001b[39mnow()\n",
+      "\u001b[0;31mKeyError\u001b[0m: 'pop from an empty set'",
+      "\nDuring handling of the above exception, another exception occurred:\n",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[1;32m/home/qubix/Documents/shared_work/iBridges/Tutorial_irodsConnector.ipynb Cell 7\u001b[0m line \u001b[0;36m1\n\u001b[0;32m----> <a href='vscode-notebook-cell:/home/qubix/Documents/shared_work/iBridges/Tutorial_irodsConnector.ipynb#W6sZmlsZQ%3D%3D?line=0'>1</a>\u001b[0m session \u001b[39m=\u001b[39m Session(irods_env_path\u001b[39m=\u001b[39;49mos\u001b[39m.\u001b[39;49mpath\u001b[39m.\u001b[39;49mexpanduser(\u001b[39m\"\u001b[39;49m\u001b[39m~/.irods/irods_environment.json\u001b[39;49m\u001b[39m\"\u001b[39;49m))\n",
+      "File \u001b[0;32m~/Documents/shared_work/iBridges/ibridges/irodsconnector/session.py:42\u001b[0m, in \u001b[0;36mSession.__init__\u001b[0;34m(self, irods_env, irods_env_path, password)\u001b[0m\n\u001b[1;32m     40\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_irods_env \u001b[39m=\u001b[39m irods_env\n\u001b[1;32m     41\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_irods_env_path \u001b[39m=\u001b[39m irods_env_path\n\u001b[0;32m---> 42\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_irods_session \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mconnect()\n",
+      "File \u001b[0;32m~/Documents/shared_work/iBridges/ibridges/irodsconnector/session.py:109\u001b[0m, in \u001b[0;36mSession.connect\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    107\u001b[0m \u001b[39mprint\u001b[39m(\u001b[39m\"\u001b[39m\u001b[39mAuth with password\u001b[39m\u001b[39m\"\u001b[39m)\n\u001b[1;32m    108\u001b[0m \u001b[39m# irods environment and given password\u001b[39;00m\n\u001b[0;32m--> 109\u001b[0m \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mauthenticate_using_password()\n",
+      "File \u001b[0;32m~/Documents/shared_work/iBridges/ibridges/irodsconnector/session.py:125\u001b[0m, in \u001b[0;36mSession.authenticate_using_password\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    123\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mException\u001b[39;00m(exceptions[\u001b[39mrepr\u001b[39m(e)]\u001b[39m+\u001b[39m\u001b[39m\"\u001b[39m\u001b[39m; \u001b[39m\u001b[39m\"\u001b[39m\u001b[39m+\u001b[39m\u001b[39mrepr\u001b[39m(e))\n\u001b[1;32m    124\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[0;32m--> 125\u001b[0m     \u001b[39mraise\u001b[39;00m e\n",
+      "File \u001b[0;32m~/Documents/shared_work/iBridges/ibridges/irodsconnector/session.py:115\u001b[0m, in \u001b[0;36mSession.authenticate_using_password\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    112\u001b[0m \u001b[39mtry\u001b[39;00m:\n\u001b[1;32m    113\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_irods_session \u001b[39m=\u001b[39m irods\u001b[39m.\u001b[39msession\u001b[39m.\u001b[39miRODSSession(password\u001b[39m=\u001b[39m\u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_password,\n\u001b[1;32m    114\u001b[0m                                                      \u001b[39m*\u001b[39m\u001b[39m*\u001b[39m\u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_irods_env)\n\u001b[0;32m--> 115\u001b[0m     \u001b[39massert\u001b[39;00m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_irods_session\u001b[39m.\u001b[39;49mserver_version \u001b[39m!=\u001b[39m ()\n\u001b[1;32m    116\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_irods_session\n\u001b[1;32m    117\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mValueError\u001b[39;00m \u001b[39mas\u001b[39;00m e:\n",
+      "File \u001b[0;32m~/.pyenv/versions/3.11.5/lib/python3.11/site-packages/irods/session.py:217\u001b[0m, in \u001b[0;36miRODSSession.server_version\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    215\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mtuple\u001b[39m(ast\u001b[39m.\u001b[39mliteral_eval(reported_vsn))\n\u001b[1;32m    216\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mSyntaxError\u001b[39;00m:  \u001b[39m# environment variable was malformed, empty, or unset\u001b[39;00m\n\u001b[0;32m--> 217\u001b[0m     \u001b[39mreturn\u001b[39;00m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m__server_version()\n",
+      "File \u001b[0;32m~/.pyenv/versions/3.11.5/lib/python3.11/site-packages/irods/session.py:224\u001b[0m, in \u001b[0;36miRODSSession.__server_version\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    222\u001b[0m     \u001b[39mreturn\u001b[39;00m conn\u001b[39m.\u001b[39mserver_version\n\u001b[1;32m    223\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mStopIteration\u001b[39;00m:\n\u001b[0;32m--> 224\u001b[0m     conn \u001b[39m=\u001b[39m \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49mpool\u001b[39m.\u001b[39;49mget_connection()\n\u001b[1;32m    225\u001b[0m     version \u001b[39m=\u001b[39m conn\u001b[39m.\u001b[39mserver_version\n\u001b[1;32m    226\u001b[0m     conn\u001b[39m.\u001b[39mrelease()\n",
+      "File \u001b[0;32m~/.pyenv/versions/3.11.5/lib/python3.11/site-packages/irods/pool.py:15\u001b[0m, in \u001b[0;36mattribute_from_return_value.<locals>.deco.<locals>.method_\u001b[0;34m(self, *s, **kw)\u001b[0m\n\u001b[1;32m     14\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39mmethod_\u001b[39m(\u001b[39mself\u001b[39m,\u001b[39m*\u001b[39ms,\u001b[39m*\u001b[39m\u001b[39m*\u001b[39mkw):\n\u001b[0;32m---> 15\u001b[0m     ret \u001b[39m=\u001b[39m method(\u001b[39mself\u001b[39;49m,\u001b[39m*\u001b[39;49ms,\u001b[39m*\u001b[39;49m\u001b[39m*\u001b[39;49mkw)\n\u001b[1;32m     16\u001b[0m     \u001b[39msetattr\u001b[39m(\u001b[39mself\u001b[39m,attrname,ret)\n\u001b[1;32m     17\u001b[0m     \u001b[39mreturn\u001b[39;00m ret\n",
+      "File \u001b[0;32m~/.pyenv/versions/3.11.5/lib/python3.11/site-packages/irods/pool.py:75\u001b[0m, in \u001b[0;36mPool.get_connection\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m     73\u001b[0m         logger\u001b[39m.\u001b[39mdebug(\u001b[39m\"\u001b[39m\u001b[39mCreated new connection with id: \u001b[39m\u001b[39m{}\u001b[39;00m\u001b[39m\"\u001b[39m\u001b[39m.\u001b[39mformat(\u001b[39mid\u001b[39m(conn)))\n\u001b[1;32m     74\u001b[0m \u001b[39mexcept\u001b[39;00m \u001b[39mKeyError\u001b[39;00m:\n\u001b[0;32m---> 75\u001b[0m     conn \u001b[39m=\u001b[39m Connection(\u001b[39mself\u001b[39;49m, \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49maccount)\n\u001b[1;32m     76\u001b[0m     logger\u001b[39m.\u001b[39mdebug(\u001b[39m\"\u001b[39m\u001b[39mNo connection found in idle set. Created a new connection with id: \u001b[39m\u001b[39m{}\u001b[39;00m\u001b[39m\"\u001b[39m\u001b[39m.\u001b[39mformat(\u001b[39mid\u001b[39m(conn)))\n\u001b[1;32m     78\u001b[0m \u001b[39mself\u001b[39m\u001b[39m.\u001b[39mactive\u001b[39m.\u001b[39madd(conn)\n",
+      "File \u001b[0;32m~/.pyenv/versions/3.11.5/lib/python3.11/site-packages/irods/connection.py:74\u001b[0m, in \u001b[0;36mConnection.__init__\u001b[0;34m(self, pool, account)\u001b[0m\n\u001b[1;32m     72\u001b[0m     \u001b[39mself\u001b[39m\u001b[39m.\u001b[39m_login_gsi()\n\u001b[1;32m     73\u001b[0m \u001b[39melif\u001b[39;00m scheme \u001b[39m==\u001b[39m PAM_AUTH_SCHEME:\n\u001b[0;32m---> 74\u001b[0m     \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49m_login_pam()\n\u001b[1;32m     75\u001b[0m \u001b[39melse\u001b[39;00m:\n\u001b[1;32m     76\u001b[0m     \u001b[39mraise\u001b[39;00m \u001b[39mValueError\u001b[39;00m(\u001b[39m\"\u001b[39m\u001b[39mUnknown authentication scheme \u001b[39m\u001b[39m%s\u001b[39;00m\u001b[39m\"\u001b[39m \u001b[39m%\u001b[39m scheme)\n",
+      "File \u001b[0;32m~/.pyenv/versions/3.11.5/lib/python3.11/site-packages/irods/connection.py:443\u001b[0m, in \u001b[0;36mConnection._login_pam\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    439\u001b[0m \u001b[39mdef\u001b[39;00m \u001b[39m_login_pam\u001b[39m(\u001b[39mself\u001b[39m):\n\u001b[1;32m    441\u001b[0m     time_to_live_in_seconds \u001b[39m=\u001b[39m \u001b[39m60\u001b[39m\n\u001b[0;32m--> 443\u001b[0m     pam_password \u001b[39m=\u001b[39m PAM_PW_ESC_PATTERN\u001b[39m.\u001b[39;49msub(\u001b[39mlambda\u001b[39;49;00m m: \u001b[39m'\u001b[39;49m\u001b[39m\\\\\u001b[39;49;00m\u001b[39m'\u001b[39;49m\u001b[39m+\u001b[39;49mm\u001b[39m.\u001b[39;49mgroup(\u001b[39m1\u001b[39;49m), \u001b[39mself\u001b[39;49m\u001b[39m.\u001b[39;49maccount\u001b[39m.\u001b[39;49mpassword)\n\u001b[1;32m    445\u001b[0m     ctx_user \u001b[39m=\u001b[39m \u001b[39m'\u001b[39m\u001b[39m%s\u001b[39;00m\u001b[39m=\u001b[39m\u001b[39m%s\u001b[39;00m\u001b[39m'\u001b[39m \u001b[39m%\u001b[39m (AUTH_USER_KEY, \u001b[39mself\u001b[39m\u001b[39m.\u001b[39maccount\u001b[39m.\u001b[39mclient_user)\n\u001b[1;32m    446\u001b[0m     ctx_pwd \u001b[39m=\u001b[39m \u001b[39m'\u001b[39m\u001b[39m%s\u001b[39;00m\u001b[39m=\u001b[39m\u001b[39m%s\u001b[39;00m\u001b[39m'\u001b[39m \u001b[39m%\u001b[39m (AUTH_PWD_KEY, pam_password)\n",
+      "\u001b[0;31mTypeError\u001b[0m: expected string or bytes-like object, got 'NoneType'"
+     ]
+    }
+   ],
    "source": [
     "session = Session(irods_env_path=os.path.expanduser(\"~/.irods/irods_environment.json\"))"
    ]
@@ -90,7 +132,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "id": "fe178d2c",
    "metadata": {},
    "outputs": [
@@ -98,7 +140,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "c.staiger@uu.nl\n",
+      "r.d.schram@uu.nl\n",
       "irodsResc\n",
       "nluu12p\n",
       "(4, 2, 12)\n"
@@ -123,7 +165,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "id": "9ae7d602",
    "metadata": {},
    "outputs": [
@@ -144,7 +186,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 6,
    "id": "2e8f3c90",
    "metadata": {},
    "outputs": [
@@ -152,14 +194,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[('AUTHOR', 'Lew Wallace', '')]\n"
+      " - {name: AUTHOR, value: Lew Wallace, units: None}\n",
+      " - {name: HUHU, value: hihi, units: None}\n",
+      " - {name: NEWKEY, value: hihi, units: None}\n",
+      "\n"
      ]
     }
    ],
    "source": [
     "from ibridges.irodsconnector.meta import MetaData\n",
     "coll_meta = MetaData(coll)\n",
-    "print(coll_meta.metadata_as_str)"
+    "print(coll_meta)"
    ]
   },
   {
@@ -167,12 +212,12 @@
    "id": "42007e1e",
    "metadata": {},
    "source": [
-    "### Add and delete metadata"
+    "### Add, set and delete metadata"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "id": "cfa7f559",
    "metadata": {},
    "outputs": [
@@ -180,13 +225,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[('AUTHOR', 'Lew Wallace', ''), ('NEWKEY', 'NewValue', '')]\n"
+      " - {name: AUTHOR, value: Lew Wallace, units: None}\n",
+      " - {name: NEWKEY, value: NewValue, units: None}\n",
+      " - {name: HUHU, value: hihi, units: None}\n",
+      " - {name: NEWKEY, value: hihi, units: None}\n",
+      "\n"
      ]
     }
    ],
    "source": [
     "coll_meta.add('NewKey', 'NewValue')\n",
-    "print(coll_meta.metadata_as_str)"
+    "print(coll_meta)"
    ]
   },
   {
@@ -199,7 +248,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "id": "d8aa144a",
    "metadata": {},
    "outputs": [
@@ -207,13 +256,34 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "[('AUTHOR', 'Lew Wallace', '')]\n"
+      " - {name: AUTHOR, value: Lew Wallace, units: None}\n",
+      " - {name: HUHU, value: hihi, units: None}\n",
+      " - {name: NEWKEY, value: hihi, units: None}\n",
+      "\n"
      ]
     }
    ],
    "source": [
     "coll_meta.delete('NEWKEY', 'NewValue')\n",
-    "print(coll_meta.metadata_as_str)"
+    "print(coll_meta)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f7b5cafa",
+   "metadata": {},
+   "source": [
+    "We can also set the meta data to a single key, value, units pair. This will remove any other entries with the same key."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "770cbec2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "coll_meta.set(\"NEWKEY\", \"OtherValue\")"
    ]
   },
   {
@@ -402,7 +472,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.11.5"
   }
  },
  "nbformat": 4,

--- a/Tutorial_irodsConnector.ipynb
+++ b/Tutorial_irodsConnector.ipynb
@@ -18,13 +18,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "b6fd51d6",
    "metadata": {},
    "outputs": [],
    "source": [
     "from ibridges.irodsconnector.session import Session\n",
-    "import os, json"
+    "import os, json\n",
+    "from getpass import getpass"
    ]
   },
   {
@@ -37,21 +38,32 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "cf36ab7b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Your iRODS password········\n",
+      "Auth with password\n"
+     ]
+    }
+   ],
    "source": [
     "with open(os.path.expanduser(\"~/.irods/irods_environment.json\"), \"r\") as f:\n",
     "    ienv = json.load(f)\n",
-    "password = \"<YOUR PASSWORD>\"\n",
+    "password = getpass(\"Your iRODS password\")\n",
     "session = Session(irods_env=ienv, password=password)"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "71f001b3",
-   "metadata": {},
+   "metadata": {
+    "heading_collapsed": true
+   },
    "source": [
     "### Using the cached password ~/.irods/.rodsA"
    ]
@@ -60,7 +72,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "242eab2c",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
     "session = Session(irods_env_path=os.path.expanduser(\"~/.irods/irods_environment.json\"))"
@@ -76,10 +90,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "fe178d2c",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "c.staiger@uu.nl\n",
+      "irodsResc\n",
+      "nluu12p\n",
+      "(4, 2, 12)\n"
+     ]
+    }
+   ],
    "source": [
     "print(session.username)\n",
     "print(session.default_resc) # the resource to which data will be uploaded\n",
@@ -89,8 +114,114 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82fb48cc",
+   "id": "8214c7fe",
    "metadata": {},
+   "source": [
+    "## Metadata of data objects and collections\n",
+    "### Retrieve an iRODS object or collection and list its metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "9ae7d602",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/nluu12p/home/research-test-christine/books/BenHur.txt\n"
+     ]
+    }
+   ],
+   "source": [
+    "#print(ienv)\n",
+    "coll_path = ienv.get('irods_home', '') + '/books/BenHur.txt'\n",
+    "print(coll_path)\n",
+    "coll = session.irods_session.data_objects.get(coll_path) # TODO: exchange once data_ops is done"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "2e8f3c90",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[('AUTHOR', 'Lew Wallace', '')]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from ibridges.irodsconnector.meta import MetaData\n",
+    "coll_meta = MetaData(coll)\n",
+    "print(coll_meta.metadata_as_str)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "42007e1e",
+   "metadata": {},
+   "source": [
+    "### Add and delete metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "cfa7f559",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[('AUTHOR', 'Lew Wallace', ''), ('NEWKEY', 'NewValue', '')]\n"
+     ]
+    }
+   ],
+   "source": [
+    "coll_meta.add('NewKey', 'NewValue')\n",
+    "print(coll_meta.metadata_as_str)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b3a046d9",
+   "metadata": {},
+   "source": [
+    "Note, that keys are always capitalised. This is good practice in iRODS."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d8aa144a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[('AUTHOR', 'Lew Wallace', '')]\n"
+     ]
+    }
+   ],
+   "source": [
+    "coll_meta.delete('NEWKEY', 'NewValue')\n",
+    "print(coll_meta.metadata_as_str)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "82fb48cc",
+   "metadata": {
+    "heading_collapsed": true
+   },
    "source": [
     "## Resources and handling resources"
    ]
@@ -99,7 +230,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7361e841",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
     "from ibridges.irodsconnector.resources import Resources\n",
@@ -109,7 +242,9 @@
   {
    "cell_type": "markdown",
    "id": "3ed14f46",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "source": [
     "### Check if default resource exists"
    ]
@@ -118,7 +253,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "26c6e657",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
     "default_resc = resources.get_resource(session._irods_env.get(\"irods_default_resource\", \"\"))\n",
@@ -130,7 +267,9 @@
   {
    "cell_type": "markdown",
    "id": "f2fa5b6e",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "source": [
     "### Listing resources"
    ]
@@ -139,7 +278,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e309d749",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
     "print(resources.resources()) # all resources\n",
@@ -149,7 +290,9 @@
   {
    "cell_type": "markdown",
    "id": "7fbfa57b",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "source": [
     "### Retrieve current free space\n",
     "In contrast to `resc.free_space` the function `get_free_space` accumulates all free space in the subtree starting with the resource as parent."
@@ -159,7 +302,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f1dc3412",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
     "resources.get_free_space(session._irods_env.get(\"irods_default_resource\", \"\")) # default resource name"
@@ -168,7 +313,9 @@
   {
    "cell_type": "markdown",
    "id": "377409c4",
-   "metadata": {},
+   "metadata": {
+    "heading_collapsed": true
+   },
    "source": [
     "## Tickets (access string to collection or data object)\n",
     "### List all tickets which you issued"
@@ -178,7 +325,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "06b5a060",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
     "from ibridges.irodsconnector.tickets import Tickets\n",
@@ -190,7 +339,9 @@
   {
    "cell_type": "markdown",
    "id": "11360619",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "source": [
     "### Issue a ticket"
    ]
@@ -199,7 +350,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f1911d89",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
     "from datetime import datetime\n",
@@ -212,7 +365,9 @@
   {
    "cell_type": "markdown",
    "id": "0306bac1",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "source": [
     "### Fetch and delete a ticket"
    ]
@@ -221,7 +376,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b1579c56",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
     "ticket = tickets.get_ticket(tickets.all_ticket_strings[0])\n",
@@ -245,7 +402,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/ibridges/irodsconnector/meta.py
+++ b/ibridges/irodsconnector/meta.py
@@ -2,13 +2,23 @@
 """
 import irods.exception
 import irods.meta
-
+from typing import Optional
 
 class MetaData():
     """Irods metadata operations """
 
     def __init__(self, item):
         self.item = item
+
+    @property
+    def metadata_as_str(self) -> list[tuple[str, str, str]]:
+        metadata = []
+        for m in self.item.metadata.items():
+            if m.units:
+                metadata.append((m.name, m.value, m.units))
+            else:
+                metadata.append((m.name, m.value, ''))
+        return metadata
 
     def add(self, key: str, value: str, units: str = None):
         """

--- a/ibridges/irodsconnector/meta.py
+++ b/ibridges/irodsconnector/meta.py
@@ -12,21 +12,14 @@ class MetaData():
     def __init__(self, item):
         self.item = item
 
-    # @property
-    # def metadata_as_str(self) -> list[tuple[str, str, str]]:
-    #     metadata = []
-    #     for m in self:
-    #         if m.units:
-    #             metadata.append((m.name, m.value, m.units))
-    #         else:
-    #             metadata.append((m.name, m.value, ''))
-    #     return metadata
-
     def __iter__(self) -> Iterator:
         for m in self.item.metadata.items():
             yield m
 
     def __repr__(self) -> str:
+        """Create a sorted representation of the metadata"""
+
+        # Sort the list of items name -> value -> units, where None is the lowest
         meta_list = list(self)
         meta_list = sorted(meta_list, key=lambda m: (m.units is None, m.units))
         meta_list = sorted(meta_list, key=lambda m: (m.value is None, m.value))

--- a/ibridges/irodsconnector/meta.py
+++ b/ibridges/irodsconnector/meta.py
@@ -58,7 +58,7 @@ class MetaData():
 
         Throws: CAT_NO_ACCESS_PERMISSION
         """
-        if key in item.metadata.keys():
+        if key in self.item.metadata.keys():
             self.delete(key, None)
         self.add(key, value, units)
 

--- a/ibridges/irodsconnector/session.py
+++ b/ibridges/irodsconnector/session.py
@@ -1,21 +1,23 @@
 """ session operations
 """
-import warnings
-import os
 import json
+import os
+import warnings
 from typing import Optional
 
 import irods.session
 from irods.exception import NetworkException
+
 from ibridges.irodsconnector.keywords import exceptions
+
 
 class Session:
     """Irods session authentication.
 
     """
 
-    def __init__(self, irods_env: Optional[dict] = None, irods_env_path: Optional[str] = None, 
-                 password: Optional[str] = None) -> irods.session:
+    def __init__(self, irods_env: Optional[dict] = None, irods_env_path: Optional[str] = None,
+                 password: Optional[str] = None):
         """ iRODS authentication with Python client.
 
         Parameters
@@ -32,7 +34,7 @@ class Session:
             warnings.warn("Environment dictionary will be overwritten with irods environment file")
         if irods_env_path:
             with open(os.path.expanduser("~/.irods/irods_environment.json"), "r") as f:
-                irods_ienv = json.load(f)
+                irods_env = json.load(f)
 
         self._password = password
         self._irods_env = irods_env

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ write_to = "ibridges/_version.py"
 
 [[tool.mypy.overrides]]
 module = [
+    "irods.*",
 ]
 ignore_missing_imports = true
 


### PR DESCRIPTION
I added an __init__ function so that a metadata object is always linked to a single item. This means that the convenience of supplying a list is gone and needs to be done at another level.

I also changed the behavior of the update/set function. I think it is more intuitive if the set function always removes the data regardless if it there were already key/value pairs.

Feedback is appreciated!