### PR TITLE
Permissions

### DIFF
--- a/Tutorial_irodsConnector.ipynb
+++ b/Tutorial_irodsConnector.ipynb
@@ -11,7 +11,9 @@
   {
    "cell_type": "markdown",
    "id": "e02a7976",
-   "metadata": {},
+   "metadata": {
+    "heading_collapsed": true
+   },
    "source": [
     "## Create an iRODS session (connection to iRODS server)"
    ]
@@ -20,7 +22,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b6fd51d6",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
     "from ibridges import Session\n",
@@ -31,7 +35,9 @@
   {
    "cell_type": "markdown",
    "id": "2cc48382",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "source": [
     "### Password authentication"
    ]
@@ -40,7 +46,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cf36ab7b",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
     "with open(os.path.expanduser(\"~/.irods/irods_environment.json\"), \"r\") as f:\n",
@@ -53,7 +61,8 @@
    "cell_type": "markdown",
    "id": "71f001b3",
    "metadata": {
-    "heading_collapsed": true
+    "heading_collapsed": true,
+    "hidden": true
    },
    "source": [
     "### Using the cached password ~/.irods/.rodsA"
@@ -74,7 +83,10 @@
   {
    "cell_type": "markdown",
    "id": "0fb9577d",
-   "metadata": {},
+   "metadata": {
+    "heading_collapsed": true,
+    "hidden": true
+   },
    "source": [
     "### Checking some session parameters"
    ]
@@ -83,7 +95,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "fe178d2c",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
     "print(session.username)\n",
@@ -339,7 +353,9 @@
   {
    "cell_type": "markdown",
    "id": "377409c4",
-   "metadata": {},
+   "metadata": {
+    "heading_collapsed": true
+   },
    "source": [
     "## Tickets (access string to collection or data object)"
    ]
@@ -348,7 +364,8 @@
    "cell_type": "markdown",
    "id": "ecc98bb6",
    "metadata": {
-    "heading_collapsed": true
+    "heading_collapsed": true,
+    "hidden": true
    },
    "source": [
     "### List all tickets which you issued"
@@ -373,7 +390,8 @@
    "cell_type": "markdown",
    "id": "11360619",
    "metadata": {
-    "heading_collapsed": true
+    "heading_collapsed": true,
+    "hidden": true
    },
    "source": [
     "### Issue a ticket"
@@ -399,7 +417,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b04270a7-d839-4c0d-950f-a529ea8b27bf",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
     "tickets.all_ticket_strings"
@@ -408,7 +428,10 @@
   {
    "cell_type": "markdown",
    "id": "0306bac1",
-   "metadata": {},
+   "metadata": {
+    "heading_collapsed": true,
+    "hidden": true
+   },
    "source": [
     "### Fetch and delete a ticket"
    ]
@@ -417,7 +440,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b1579c56",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
     "ticket = tickets.get_ticket(tickets.all_ticket_strings[0])\n",
@@ -427,7 +452,9 @@
   {
    "cell_type": "markdown",
    "id": "e99c08e5",
-   "metadata": {},
+   "metadata": {
+    "heading_collapsed": true
+   },
    "source": [
     "## Rules\n",
     "Execute an iRODS rule from a rule file:"
@@ -437,7 +464,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3913b742",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
     "from ibridges.irodsconnector.rules import Rules\n",
@@ -450,7 +479,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "900f8ab2",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
     "print(stdout)\n",
@@ -460,7 +491,9 @@
   {
    "cell_type": "markdown",
    "id": "97970ce3",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "source": [
     "### Overwrite parameters in iRODS rules\n",
     "iRODS rule files end with a line like `input *in=\"This is a string or a path or etc\"`. In this example there is an input parameter called `'*in'` and it takes the value `\"This is a string or a path or etc\"`. We can overwrite these values by passing a python dictionary:"
@@ -470,7 +503,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5a6ce87a",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
     "params = {'*in': '\"Another input\"'}\n",
@@ -481,7 +516,9 @@
   {
    "cell_type": "markdown",
    "id": "afb54c03",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "source": [
     "Changing the type of the parameter from str to int, you can also see that keys in the dictionary which do not correspond to an input parameter, are simply ignored."
    ]
@@ -490,7 +527,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d06d1f54",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
     "params = {'*in': 4, '*another_val': '\"Value\"'}\n",
@@ -503,165 +542,174 @@
    "id": "30a2d4a6",
    "metadata": {},
    "source": [
-    "## Permissions\n",
-    "### Reading and setting access for objects (files)\n",
+    "## Permissions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0abc7c82",
+   "metadata": {
+    "heading_collapsed": true
+   },
+   "source": [
+    "### Accessing the permissions of a data object or collection in iRODS\n",
     "\n",
-    "Object and collections can have permissions attached to them. Permissions, which work like access levels, must be specified per user. The basic permissions are 'own' (implies reading and writing), 'write' (implies reading), and 'read'."
+    "Objects and collections have permissions attached to them. Permissions, which work like access levels, must be specified per user or group. The basic permissions are `own` (implies reading and writing), `modify object` (editing and reading), and `read object`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "1eb3a627",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
     "from ibridges.irodsconnector.permission import Permission\n",
     "\n",
-    "def show_permissions(obj, user=None):\n",
-    "    for perm in obj:\n",
-    "        if user is None or user and user==perm.user_name:\n",
-    "            print(f\"{perm.path} {perm.access_name:<13} {perm.user_name} ({perm.user_type}) {perm.user_zone}\")\n",
+    "# select a file to inspect and set permissions on\n",
+    "item_path = ienv.get('irods_home', '/'+session.zone+'/home') # Path to collection or data object\n",
+    "item = session.irods_session.collections.get(item_path) # TODO: exchange once data_ops is done\n",
     "\n",
-    "# define a user to set permissions for\n",
-    "my_user='my_user'\n",
-    "\n",
-    "# select a file to set permissions on\n",
-    "obj_path = ienv.get('irods_home', '') + '/books/Dracula.txt'\n",
-    "\n",
-    "print(obj_path)\n",
-    "\n",
-    "obj = session.irods_session.data_objects.get(obj_path) # TODO: exchange once data_ops is done"
+    "# instantiate permissions with that object\n",
+    "perm = Permission(session, item)\n",
+    "print(f'Permissions for {item_path}:\\n')\n",
+    "print(perm)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b84f75ba",
-   "metadata": {},
+   "id": "f2d1c093",
+   "metadata": {
+    "heading_collapsed": true
+   },
    "source": [
-    "Create a Permission-object for interacting with an object's permissions:"
+    "### Available permissions on your iRODS server"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54cf9679",
-   "metadata": {},
+   "id": "691dbaa1",
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
-    "obj_perm = Permission(session, obj)\n",
-    "show_permissions(obj_perm)\n",
-    "\n",
-    "original_permission=None\n",
-    "perms=[x for x in obj_perm if x.user_name==my_user]\n",
-    "if len(perms)>0:\n",
-    "    # remember current access level to the file for my_user\n",
-    "    original_permission=perms[0].access_name "
+    "obj_perm.available_permissions.codes"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "a5cf23d6",
-   "metadata": {},
+   "id": "b84f75ba",
+   "metadata": {
+    "heading_collapsed": true
+   },
    "source": [
-    "New permissions can be set for the object, overwriting the existing value."
+    "### Adding permissions to a collection or data object"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "4e2e1737",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
-    "print(\"current: \", original_permission)\n",
-    "new_permission='modify_object' if original_permission in ['read object', 'read_object'] else 'read_object'\n",
-    "print(\"new: \", new_permission)\n",
-    "\n",
-    "obj_perm.set(new_permission, my_user)\n",
-    "show_permissions(obj_perm)\n",
-    "\n",
-    "obj_perm.set(original_permission, my_user)"
+    "perm.set('modify object', '<username or group name>')\n",
+    "print(perm)"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "e5779c58",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "source": [
-    "See available permissions. Note that some permission-types have synonyms:\n",
+    "Note that some permission-types have synonyms:\n",
     "\n",
     "+ read object: 'read', 'read object', 'read_object'\n",
-    "+ modify object: 'write', 'modify object', 'modify_object'\n",
-    "\n",
-    "Setting 'null' removes the current permission."
+    "+ modify object: 'write', 'modify object', 'modify_object'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8c2ba10d",
+   "metadata": {
+    "heading_collapsed": true
+   },
+   "source": [
+    "### Removing permissions"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "21bda746",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
-    "print(obj_perm.available_permissions.keys())"
+    "perm.set('null', '<username or group name>')\n",
+    "print(perm)"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "4d52f16b",
-   "metadata": {},
+   "metadata": {
+    "heading_collapsed": true
+   },
    "source": [
-    "### Reading and setting access for collections (folders)\n",
-    "\n",
-    "The method also works for collections:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d5e27cb0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "coll_path = ienv.get('irods_home', '') + '/books/'\n",
-    "\n",
-    "print(coll_path)\n",
-    "\n",
-    "coll = session.irods_session.collections.get(coll_path) # TODO: exchange once data_ops is done\n",
-    "coll_perm = Permission(session, coll)\n",
-    "\n",
-    "coll_perm.set('read', my_user)\n",
-    "show_permissions(coll_perm, my_user)\n",
-    "coll_perm.set('write', my_user)\n",
-    "show_permissions(coll_perm, my_user)\n"
+    "### Inheritance"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "a5264aee",
-   "metadata": {},
+   "id": "76942f18",
+   "metadata": {
+    "hidden": true
+   },
    "source": [
-    "In addition, collections support setting 'inherit' and 'noinherit'  (link to documentation?). This is a property rather than a permission, and is independent of any user."
+    "Collections have two special permissions level `inherit` and `noinherit`. From the point in time where inheritance in switched on, all newly added subcollections and data objects will inherit their initial permissions from the collection."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "60251c8a",
-   "metadata": {},
+   "metadata": {
+    "hidden": true
+   },
    "outputs": [],
    "source": [
-    "original_inheritance=coll.inheritance\n",
-    "print(\"old value: \", original_inheritance)\n",
+    "# Retrieve a collection from iRODS\n",
+    "coll_path = ienv.get('irods_home1', '/'+session.zone+'/home')\n",
+    "coll = session.irods_session.collections.get(item_path)\n",
+    "coll_perm = Permission(session, coll)\n",
     "\n",
-    "coll_perm.set('noinherit' if original_inheritance else 'inherit')\n",
-    "\n",
-    "# old value is cached in the session, retrieve anew to see change\n",
-    "coll = session.irods_session.collections.get(coll_path) # TODO: exchange once data_ops is done\n",
-    "print(\"new value: \", coll.inheritance)\n",
-    "\n",
-    "coll_perm.set('inherit' if original_inheritance else 'noinherit')"
+    "#Switch inheritance on\n",
+    "coll_perm.set('inherit')\n",
+    "print(coll_perm)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ec9bd025",
+   "metadata": {
+    "hidden": true
+   },
+   "outputs": [],
+   "source": [
+    "# Switch inheritance off\n",
+    "coll_perm.set('noinherit')\n",
+    "print(coll_perm)"
    ]
   }
  ],
@@ -681,7 +729,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.16"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/Tutorial_irodsConnector.ipynb
+++ b/Tutorial_irodsConnector.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "b6fd51d6",
    "metadata": {},
    "outputs": [],
@@ -499,12 +499,264 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "ae0efa00",
+   "cell_type": "markdown",
+   "id": "f4df99c5",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "## Permissions\n",
+    "### Reading and setting access for objects (files)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "3123c35c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/nluu12p/home/research-test-christine/books/Dracula.txt\n"
+     ]
+    }
+   ],
+   "source": [
+    "from ibridges.irodsconnector.permission import Permission\n",
+    "\n",
+    "def show_permissions(obj, user=None):\n",
+    "    for perm in obj:\n",
+    "        if user is None or user and user==perm.user_name:\n",
+    "            print(f\"{perm.path} {perm.access_name:<13} {perm.user_name} ({perm.user_type}) {perm.user_zone}\")\n",
+    "\n",
+    "# define a user to set permissions for\n",
+    "my_user='my_user'\n",
+    "\n",
+    "# select a file to set permissions on\n",
+    "obj_path = ienv.get('irods_home', '') + '/books/Dracula.txt'\n",
+    "\n",
+    "print(obj_path)\n",
+    "\n",
+    "obj = session.irods_session.data_objects.get(obj_path) # TODO: exchange once data_ops is done"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "e518198c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/nluu12p/home/research-test-christine/books/Dracula.txt read object   datamanager-its (rodsgroup) nluu12p\n",
+      "/nluu12p/home/research-test-christine/books/Dracula.txt read object   m.d.schermer@uu.nl (rodsuser) nluu12p\n",
+      "/nluu12p/home/research-test-christine/books/Dracula.txt read object   read-test-christine (rodsgroup) nluu12p\n",
+      "/nluu12p/home/research-test-christine/books/Dracula.txt own           research-test-christine (rodsgroup) nluu12p\n",
+      "/nluu12p/home/research-test-christine/books/Dracula.txt own           rods (rodsadmin) nluu12p\n"
+     ]
+    }
+   ],
+   "source": [
+    "# create Permission object for the file\n",
+    "obj_perm = Permission(session, obj)\n",
+    "\n",
+    "# see the current permissions set on the file\n",
+    "show_permissions(obj_perm)\n",
+    "\n",
+    "# remember current access level to the file for my_user\n",
+    "original_permission=None\n",
+    "perms=[x for x in obj_perm if x.user_name==my_user]\n",
+    "if len(perms)>0:\n",
+    "    original_permission=perms[0].access_name"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "073916fb",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "current:  read object\n",
+      "new:  modify_object\n",
+      "/nluu12p/home/research-test-christine/books/Dracula.txt read object   datamanager-its (rodsgroup) nluu12p\n",
+      "/nluu12p/home/research-test-christine/books/Dracula.txt modify object m.d.schermer@uu.nl (rodsuser) nluu12p\n",
+      "/nluu12p/home/research-test-christine/books/Dracula.txt read object   read-test-christine (rodsgroup) nluu12p\n",
+      "/nluu12p/home/research-test-christine/books/Dracula.txt own           research-test-christine (rodsgroup) nluu12p\n",
+      "/nluu12p/home/research-test-christine/books/Dracula.txt own           rods (rodsadmin) nluu12p\n"
+     ]
+    }
+   ],
+   "source": [
+    "# define a new access level\n",
+    "print(\"current: \", original_permission)\n",
+    "new_permission='modify_object' if original_permission in ['read object', 'read_object'] else 'read_object'\n",
+    "print(\"new: \", new_permission)\n",
+    "\n",
+    "# set the new access level\n",
+    "obj_perm.set(new_permission, my_user)\n",
+    "\n",
+    "# see the updated access level for my_user\n",
+    "show_permissions(obj_perm)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "948afa08",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['null', 'read object', 'modify object', 'own']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# available access levels:\n",
+    "print(obj_perm.available_permissions.keys())\n",
+    "\n",
+    "# several synonyms can be used:\n",
+    "obj_perm.set('read', my_user)\n",
+    "obj_perm.set('read object', my_user)\n",
+    "obj_perm.set('read_object', my_user)\n",
+    "\n",
+    "obj_perm.set('write', my_user)\n",
+    "obj_perm.set('modify object', my_user)\n",
+    "obj_perm.set('modify_object', my_user)\n",
+    "obj_perm.set('modify_object', my_user)\n",
+    "\n",
+    "obj_perm.set(original_permission, my_user)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6f27adef",
+   "metadata": {},
+   "source": [
+    "### Reading and setting access for collections (folders)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "86af2400",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/nluu12p/home/research-test-christine/books/\n"
+     ]
+    }
+   ],
+   "source": [
+    "# select a file to set permissions on\n",
+    "coll_path = ienv.get('irods_home', '') + '/books/'\n",
+    "\n",
+    "print(coll_path)\n",
+    "\n",
+    "coll = session.irods_session.collections.get(coll_path) # TODO: exchange once data_ops is done\n",
+    "coll_perm = Permission(session, coll)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "b726383a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/nluu12p/home/research-test-christine/books own           m.d.schermer@uu.nl (rodsuser) nluu12p\n",
+      "/nluu12p/home/research-test-christine/books modify object m.d.schermer@uu.nl (rodsuser) nluu12p\n"
+     ]
+    }
+   ],
+   "source": [
+    "# see all access levels for the collection for your user\n",
+    "show_permissions(coll_perm, my_user)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "e61d5c8a",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/nluu12p/home/research-test-christine/books own           m.d.schermer@uu.nl (rodsuser) nluu12p\n",
+      "/nluu12p/home/research-test-christine/books read object   m.d.schermer@uu.nl (rodsuser) nluu12p\n"
+     ]
+    }
+   ],
+   "source": [
+    "# set new access level\n",
+    "coll_perm.set('read', my_user)\n",
+    "show_permissions(coll_perm, my_user)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "cc7c139c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# in addition, collections support 'inherit' and 'noinherit' permissions (link to documentation?)\n",
+    "# current inheritance state\n",
+    "coll.inheritance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "id": "bb877022",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "False"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# set new value\n",
+    "coll_perm.set('noinherit' if coll.inheritance else 'inherit')\n",
+    "\n",
+    "# old value is cached in the session, retrieve anew to see change\n",
+    "coll = session.irods_session.collections.get(coll_path) # TODO: exchange once data_ops is done\n",
+    "coll.inheritance"
+   ]
   }
  ],
  "metadata": {
@@ -523,7 +775,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.7.16"
   }
  },
  "nbformat": 4,

--- a/Tutorial_irodsConnector.ipynb
+++ b/Tutorial_irodsConnector.ipynb
@@ -499,36 +499,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 4,
-   "id": "56df0730",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Auth with password\n"
-     ]
-    }
-   ],
-   "source": [
-    "\n",
-    "\n",
-    "from ibridges import Session\n",
-    "import os, json\n",
-    "from getpass import getpass\n",
-    "\n",
-    "\n",
-    "with open(os.path.expanduser(\"~/.irods/irods_environment.json\"), \"r\") as f:\n",
-    "    ienv = json.load(f)\n",
-    "password = 'b9lQDcS4SOYW6z9Sst_ewMAE3eItEoL6'\n",
-    "\n",
-    "\n",
-    "session = Session(irods_env=ienv, password=password)\n"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "30a2d4a6",
    "metadata": {},
@@ -541,18 +511,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "1eb3a627",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "/nluu12p/home/research-test-christine/books/Dracula.txt\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from ibridges.irodsconnector.permission import Permission\n",
     "\n",
@@ -563,10 +525,9 @@
     "\n",
     "# define a user to set permissions for\n",
     "my_user='my_user'\n",
-    "my_user='m.d.schermer@uu.nl'\n",
     "\n",
     "# select a file to set permissions on\n",
-    "obj_path = ienv.get('irods_home', '') + '/research-test-christine/books/Dracula.txt'\n",
+    "obj_path = ienv.get('irods_home', '') + '/books/Dracula.txt'\n",
     "\n",
     "print(obj_path)\n",
     "\n",
@@ -583,22 +544,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "54cf9679",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "/nluu12p/home/research-test-christine/books/Dracula.txt read object   datamanager-its (rodsgroup) nluu12p\n",
-      "/nluu12p/home/research-test-christine/books/Dracula.txt read object   m.d.schermer@uu.nl (rodsuser) nluu12p\n",
-      "/nluu12p/home/research-test-christine/books/Dracula.txt read object   read-test-christine (rodsgroup) nluu12p\n",
-      "/nluu12p/home/research-test-christine/books/Dracula.txt own           research-test-christine (rodsgroup) nluu12p\n",
-      "/nluu12p/home/research-test-christine/books/Dracula.txt own           rods (rodsadmin) nluu12p\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "obj_perm = Permission(session, obj)\n",
     "show_permissions(obj_perm)\n",
@@ -620,24 +569,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "4e2e1737",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "current:  read object\n",
-      "new:  modify_object\n",
-      "/nluu12p/home/research-test-christine/books/Dracula.txt read object   datamanager-its (rodsgroup) nluu12p\n",
-      "/nluu12p/home/research-test-christine/books/Dracula.txt modify object m.d.schermer@uu.nl (rodsuser) nluu12p\n",
-      "/nluu12p/home/research-test-christine/books/Dracula.txt read object   read-test-christine (rodsgroup) nluu12p\n",
-      "/nluu12p/home/research-test-christine/books/Dracula.txt own           research-test-christine (rodsgroup) nluu12p\n",
-      "/nluu12p/home/research-test-christine/books/Dracula.txt own           rods (rodsadmin) nluu12p\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"current: \", original_permission)\n",
     "new_permission='modify_object' if original_permission in ['read object', 'read_object'] else 'read_object'\n",
@@ -664,18 +599,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "21bda746",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['null', 'read object', 'modify object', 'own']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(obj_perm.available_permissions.keys())"
    ]

--- a/Tutorial_irodsConnector.ipynb
+++ b/Tutorial_irodsConnector.ipynb
@@ -18,7 +18,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "b6fd51d6",
    "metadata": {},
    "outputs": [],
@@ -499,18 +499,50 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "56df0730",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Auth with password\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "\n",
+    "from ibridges import Session\n",
+    "import os, json\n",
+    "from getpass import getpass\n",
+    "\n",
+    "\n",
+    "with open(os.path.expanduser(\"~/.irods/irods_environment.json\"), \"r\") as f:\n",
+    "    ienv = json.load(f)\n",
+    "password = 'b9lQDcS4SOYW6z9Sst_ewMAE3eItEoL6'\n",
+    "\n",
+    "\n",
+    "session = Session(irods_env=ienv, password=password)\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "id": "f4df99c5",
+   "id": "30a2d4a6",
    "metadata": {},
    "source": [
     "## Permissions\n",
-    "### Reading and setting access for objects (files)"
+    "### Reading and setting access for objects (files)\n",
+    "\n",
+    "Object and collections can have permissions attached to them. Permissions, which work like access levels, must be specified per user. The basic permissions are 'own' (implies reading and writing), 'write' (implies reading), and 'read'."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
-   "id": "3123c35c",
+   "execution_count": 8,
+   "id": "1eb3a627",
    "metadata": {},
    "outputs": [
     {
@@ -531,9 +563,10 @@
     "\n",
     "# define a user to set permissions for\n",
     "my_user='my_user'\n",
+    "my_user='m.d.schermer@uu.nl'\n",
     "\n",
     "# select a file to set permissions on\n",
-    "obj_path = ienv.get('irods_home', '') + '/books/Dracula.txt'\n",
+    "obj_path = ienv.get('irods_home', '') + '/research-test-christine/books/Dracula.txt'\n",
     "\n",
     "print(obj_path)\n",
     "\n",
@@ -541,9 +574,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "b84f75ba",
+   "metadata": {},
+   "source": [
+    "Create a Permission-object for interacting with an object's permissions:"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 24,
-   "id": "e518198c",
+   "execution_count": 9,
+   "id": "54cf9679",
    "metadata": {},
    "outputs": [
     {
@@ -559,23 +600,28 @@
     }
    ],
    "source": [
-    "# create Permission object for the file\n",
     "obj_perm = Permission(session, obj)\n",
-    "\n",
-    "# see the current permissions set on the file\n",
     "show_permissions(obj_perm)\n",
     "\n",
-    "# remember current access level to the file for my_user\n",
     "original_permission=None\n",
     "perms=[x for x in obj_perm if x.user_name==my_user]\n",
     "if len(perms)>0:\n",
-    "    original_permission=perms[0].access_name"
+    "    # remember current access level to the file for my_user\n",
+    "    original_permission=perms[0].access_name "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5cf23d6",
+   "metadata": {},
+   "source": [
+    "New permissions can be set for the object, overwriting the existing value."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 25,
-   "id": "073916fb",
+   "id": "4e2e1737",
    "metadata": {},
    "outputs": [
     {
@@ -593,22 +639,33 @@
     }
    ],
    "source": [
-    "# define a new access level\n",
     "print(\"current: \", original_permission)\n",
     "new_permission='modify_object' if original_permission in ['read object', 'read_object'] else 'read_object'\n",
     "print(\"new: \", new_permission)\n",
     "\n",
-    "# set the new access level\n",
     "obj_perm.set(new_permission, my_user)\n",
+    "show_permissions(obj_perm)\n",
     "\n",
-    "# see the updated access level for my_user\n",
-    "show_permissions(obj_perm)"
+    "obj_perm.set(original_permission, my_user)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e5779c58",
+   "metadata": {},
+   "source": [
+    "See available permissions. Note that some permission-types have synonyms:\n",
+    "\n",
+    "+ read object: 'read', 'read object', 'read_object'\n",
+    "+ modify object: 'write', 'modify object', 'modify_object'\n",
+    "\n",
+    "Setting 'null' removes the current permission."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
-   "id": "948afa08",
+   "execution_count": 27,
+   "id": "21bda746",
    "metadata": {},
    "outputs": [
     {
@@ -620,142 +677,64 @@
     }
    ],
    "source": [
-    "# available access levels:\n",
-    "print(obj_perm.available_permissions.keys())\n",
-    "\n",
-    "# several synonyms can be used:\n",
-    "obj_perm.set('read', my_user)\n",
-    "obj_perm.set('read object', my_user)\n",
-    "obj_perm.set('read_object', my_user)\n",
-    "\n",
-    "obj_perm.set('write', my_user)\n",
-    "obj_perm.set('modify object', my_user)\n",
-    "obj_perm.set('modify_object', my_user)\n",
-    "obj_perm.set('modify_object', my_user)\n",
-    "\n",
-    "obj_perm.set(original_permission, my_user)"
+    "print(obj_perm.available_permissions.keys())"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "6f27adef",
+   "id": "4d52f16b",
    "metadata": {},
    "source": [
-    "### Reading and setting access for collections (folders)"
+    "### Reading and setting access for collections (folders)\n",
+    "\n",
+    "The method also works for collections:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
-   "id": "86af2400",
+   "execution_count": null,
+   "id": "d5e27cb0",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "/nluu12p/home/research-test-christine/books/\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# select a file to set permissions on\n",
     "coll_path = ienv.get('irods_home', '') + '/books/'\n",
     "\n",
     "print(coll_path)\n",
     "\n",
     "coll = session.irods_session.collections.get(coll_path) # TODO: exchange once data_ops is done\n",
-    "coll_perm = Permission(session, coll)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 30,
-   "id": "b726383a",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "/nluu12p/home/research-test-christine/books own           m.d.schermer@uu.nl (rodsuser) nluu12p\n",
-      "/nluu12p/home/research-test-christine/books modify object m.d.schermer@uu.nl (rodsuser) nluu12p\n"
-     ]
-    }
-   ],
-   "source": [
-    "# see all access levels for the collection for your user\n",
-    "show_permissions(coll_perm, my_user)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 31,
-   "id": "e61d5c8a",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "/nluu12p/home/research-test-christine/books own           m.d.schermer@uu.nl (rodsuser) nluu12p\n",
-      "/nluu12p/home/research-test-christine/books read object   m.d.schermer@uu.nl (rodsuser) nluu12p\n"
-     ]
-    }
-   ],
-   "source": [
-    "# set new access level\n",
+    "coll_perm = Permission(session, coll)\n",
+    "\n",
     "coll_perm.set('read', my_user)\n",
-    "show_permissions(coll_perm, my_user)"
+    "show_permissions(coll_perm, my_user)\n",
+    "coll_perm.set('write', my_user)\n",
+    "show_permissions(coll_perm, my_user)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a5264aee",
+   "metadata": {},
+   "source": [
+    "In addition, collections support setting 'inherit' and 'noinherit'  (link to documentation?). This is a property rather than a permission, and is independent of any user."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
-   "id": "cc7c139c",
+   "execution_count": null,
+   "id": "60251c8a",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 44,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "# in addition, collections support 'inherit' and 'noinherit' permissions (link to documentation?)\n",
-    "# current inheritance state\n",
-    "coll.inheritance"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 45,
-   "id": "bb877022",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "False"
-      ]
-     },
-     "execution_count": 45,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "# set new value\n",
-    "coll_perm.set('noinherit' if coll.inheritance else 'inherit')\n",
+    "original_inheritance=coll.inheritance\n",
+    "print(\"old value: \", original_inheritance)\n",
+    "\n",
+    "coll_perm.set('noinherit' if original_inheritance else 'inherit')\n",
     "\n",
     "# old value is cached in the session, retrieve anew to see change\n",
     "coll = session.irods_session.collections.get(coll_path) # TODO: exchange once data_ops is done\n",
-    "coll.inheritance"
+    "print(\"new value: \", coll.inheritance)\n",
+    "\n",
+    "coll_perm.set('inherit' if original_inheritance else 'noinherit')"
    ]
   }
  ],

--- a/Tutorial_irodsConnector.ipynb
+++ b/Tutorial_irodsConnector.ipynb
@@ -566,14 +566,14 @@
    },
    "outputs": [],
    "source": [
-    "from ibridges.irodsconnector.permission import Permission\n",
+    "from ibridges.irodsconnector.permissions import Permissions\n",
     "\n",
     "# select a file to inspect and set permissions on\n",
     "item_path = ienv.get('irods_home', '/'+session.zone+'/home') # Path to collection or data object\n",
     "item = session.irods_session.collections.get(item_path) # TODO: exchange once data_ops is done\n",
     "\n",
     "# instantiate permissions with that object\n",
-    "perm = Permission(session, item)\n",
+    "perm = Permissions(session, item)\n",
     "print(f'Permissions for {item_path}:\\n')\n",
     "print(perm)"
    ]
@@ -691,7 +691,7 @@
     "# Retrieve a collection from iRODS\n",
     "coll_path = ienv.get('irods_home1', '/'+session.zone+'/home')\n",
     "coll = session.irods_session.collections.get(item_path)\n",
-    "coll_perm = Permission(session, coll)\n",
+    "coll_perm = Permissions(session, coll)\n",
     "\n",
     "#Switch inheritance on\n",
     "coll_perm.set('inherit')\n",

--- a/ibridges/irodsconnector/permission.py
+++ b/ibridges/irodsconnector/permission.py
@@ -19,8 +19,8 @@ class Permission():
     def __repr__(self) -> str:
         acl_string = ""
         for m in self.session.irods_session.permissions.get(self.item):
-            acl_string += f"{m.path}: {m.user_name} ({m.user_zone}): {m.access_name} {m.inheritance}\n"
-            # acl_string += f"{repr(m)}\n"
+            # acl_string += f"{m.path}: {m.user_name} ({m.user_zone}): {m.access_name}\n"
+            acl_string += f"{repr(m)}\n"
         return acl_string
 
     #TODO: why do we need this?

--- a/ibridges/irodsconnector/permission.py
+++ b/ibridges/irodsconnector/permission.py
@@ -17,7 +17,7 @@ class Permission():
         for perm in self.session.irods_session.permissions.get(self.item):
             yield perm
 
-    def __repr__(self) -> str:
+    def __str__(self) -> str:
         acl_dict = defaultdict(list)
         for p in self:
             acl_dict[f'{p.user_name}#{p.user_zone}\n'].append(

--- a/ibridges/irodsconnector/permission.py
+++ b/ibridges/irodsconnector/permission.py
@@ -23,7 +23,7 @@ class Permission():
 
         if isinstance(self.item, irods.collection.iRODSCollection):
             coll = self.session.irods_session.collections.get(self.item.path)
-            acl_string += f"<iRODSAccess inheritance {coll.inheritance} {self.item.path}>\n"
+            acl_string += f"inheritance {coll.inheritance} {self.item.path}\n"
 
         return acl_string
 

--- a/ibridges/irodsconnector/permission.py
+++ b/ibridges/irodsconnector/permission.py
@@ -35,18 +35,7 @@ class Permission():
     @property
     def available_permissions(self) -> dict:
         """Get available permissions"""
-        try:
-            return self.session.irods_session.available_permissions
-        except AttributeError:
-            permissions = {
-                'null': 'none',
-                'read_object': 'read',
-                'modify_object': 'write',
-                'own': 'own',
-            }
-            if self.session.server_version < (4, 3, 0):
-                permissions.update({'read object': 'read', 'modify object': 'write'})
-            return permissions
+        return self.session.irods_session.available_permissions
 
     def set(self, perm: str, user: str = '', zone: str = '',
             recursive: bool = False, admin: bool = False) -> None:

--- a/ibridges/irodsconnector/permission.py
+++ b/ibridges/irodsconnector/permission.py
@@ -20,12 +20,11 @@ class Permission():
     def __str__(self) -> str:
         acl_dict = defaultdict(list)
         for p in self:
-            acl_dict[f'{p.user_name}#{p.user_zone}\n'].append(
-                    f'\t{p.access_name}\t{p.user_type}\n')
+            acl_dict[f'{p.user_name}#{p.user_zone}'].append(f'{p.access_name}\t{p.user_type}')
         acl = ''
         for key, value in sorted(acl_dict.items()):
-            acl += key + ''.join(value)
-            
+            v_str= '\n\t'.join(value)
+            acl += f'{key}\n\t{v_str}\n'
 
         if isinstance(self.item, irods.collection.iRODSCollection):
             coll = self.session.irods_session.collections.get(self.item.path)

--- a/ibridges/irodsconnector/permission.py
+++ b/ibridges/irodsconnector/permission.py
@@ -17,15 +17,15 @@ class Permission():
             yield perm
 
     def __repr__(self) -> str:
-        acl_string = ""
-        for perm in self.session.irods_session.permissions.get(self.item):
-            acl_string += f"{repr(perm)}\n"
+        acl = ""
+        for p in self.session.irods_session.permissions.get(self.item):
+            acl += f"{p.access_name.replace(' ','_')} {p.user_name}#{p.user_zone} ({p.user_type})\n"
 
         if isinstance(self.item, irods.collection.iRODSCollection):
             coll = self.session.irods_session.collections.get(self.item.path)
-            acl_string += f"inheritance {coll.inheritance} {self.item.path}\n"
+            acl += f"inheritance {coll.inheritance}\n"
 
-        return acl_string
+        return acl
 
     @property
     def available_permissions(self) -> dict:

--- a/ibridges/irodsconnector/permission.py
+++ b/ibridges/irodsconnector/permission.py
@@ -1,9 +1,9 @@
 """ permission operations """
+from typing import Iterator
 import irods.access
 import irods.collection
 import irods.exception
 import irods.session
-from typing import Iterator, Union
 
 class Permission():
     """Irods permission operations"""
@@ -13,13 +13,13 @@ class Permission():
         self.item = item
 
     def __iter__(self) -> Iterator:
-        for m in self.session.irods_session.permissions.get(self.item):
-            yield m
+        for perm in self.session.irods_session.permissions.get(self.item):
+            yield perm
 
     def __repr__(self) -> str:
         acl_string = ""
-        for m in self.session.irods_session.permissions.get(self.item):
-            acl_string += f"{repr(m)}\n"
+        for perm in self.session.irods_session.permissions.get(self.item):
+            acl_string += f"{repr(perm)}\n"
 
         if isinstance(self.item, irods.collection.iRODSCollection):
             coll = self.session.irods_session.collections.get(self.item.path)
@@ -29,9 +29,10 @@ class Permission():
 
     @property
     def available_permissions(self) -> dict:
+        """Get available permissions"""
         try:
             return self.session.irods_session.available_permissions
-        except:
+        except AttributeError:
             permissions = {
                 'null': 'none',
                 'read_object': 'read',
@@ -42,7 +43,8 @@ class Permission():
                 permissions.update({'read object': 'read', 'modify object': 'write'})
             return permissions
 
-    def set(self, perm: str, user: str = '', zone: str = '', recursive: bool = False, admin: bool = False) -> None:
+    def set(self, perm: str, user: str = '', zone: str = '',        #pylint: disable=too-many-arguments
+            recursive: bool = False, admin: bool = False) -> None:
         """Set permissions (ACL) for an iRODS collection or data object."""
         acl = irods.access.iRODSAccess(perm, self.item.path, user, zone)
         self.session.irods_session.permissions.set(acl, recursive=recursive, admin=admin)

--- a/ibridges/irodsconnector/permissions.py
+++ b/ibridges/irodsconnector/permissions.py
@@ -6,8 +6,8 @@ import irods.exception
 import irods.session
 from collections import defaultdict
 
-class Permission():
-    """Irods permission operations"""
+class Permissions():
+    """Irods permissions operations"""
 
     def __init__(self, session, item) -> None:
         self.session = session


### PR DESCRIPTION
Streamlined permissions, added bits to the tutorial notebook.

Not sure if we require a minimum version of `python-irodsclient` is, but if we do and it's at last > 1.1.5, then the try/except in `available_permissions()` can go.

`__repr__` currently copies the output of the `repr()` of the underlying `iRODSAccess` objects (like `<iRODSAccess read_object /nluu12p/home/research-test-christine/books/Dracula.txt m.d.schermer@uu.nl(rodsuser) nluu12p>`), let me know if that works. For collections, the value for the inheritance-state is added to the list.