### PR TITLE
Inspect docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,3 +23,4 @@ services:
             dockerfile: ./docker/irods_client/Dockerfile
         depends_on:
             - irods-catalog-provider
+        tty: true

--- a/docker/README.md
+++ b/docker/README.md
@@ -28,6 +28,11 @@ Clean up
 1. `docker image prune`
 2. `docker container prune`
 
+Enter the irods-client
+1. Bring the images up
+2. `docker ps`
+3. `docker exec -it <IMAGE> /bin/bash`
+
 ## Example output:
 
 ```

--- a/docker/irods_client/Dockerfile
+++ b/docker/irods_client/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /tmp/*
 
 RUN mkdir -p /root/.irods
+COPY docker/irods_client/environments/plain-irods/irods_environment.json /root/.irods
 
 RUN mkdir -p /tmp
 ADD docker/irods_client/testdata /tmp/testdata/

--- a/docker/irods_client/Dockerfile
+++ b/docker/irods_client/Dockerfile
@@ -7,12 +7,13 @@ RUN apt-get update && \
         apt-transport-https \
         gnupg \
         wget \
+	lsb-release \
     && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*
 
-# RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
-    # echo "deb [arch=amd64] https://packages.irods.org/apt/ focal main" | tee /etc/apt/sources.list.d/renci-irods.list
+RUN wget -qO - https://packages.irods.org/irods-signing-key.asc | apt-key add - && \
+    echo "deb [arch=amd64] https://packages.irods.org/apt/ $(lsb_release -sc) main" | tee /etc/apt/sources.list.d/renci-irods.list
 
 # ARG icommands_version=4.3.0
 # ARG icommands_package_version_suffix=-1~focal
@@ -21,6 +22,8 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get install -y \
         netcat \
+	irods-runtime \
+	irods-icommands \
     && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/*

--- a/docker/irods_client/entrypoint.sh
+++ b/docker/irods_client/entrypoint.sh
@@ -22,8 +22,9 @@ done
 echo "iRODS is ready"
 
 # pre-authenticate the user so the iCommands are ready to use
-# echo 'rods' | iinit
-# echo 'Authenticated as rods'
+cat ~/.irods/irods_environment.json
+echo 'rods' | iinit
+echo 'Authenticated as rods'
 
 cd /ibridges/integration_test
 pytest .

--- a/docker/irods_client/entrypoint.sh
+++ b/docker/irods_client/entrypoint.sh
@@ -25,6 +25,7 @@ echo "iRODS is ready"
 cat ~/.irods/irods_environment.json
 echo 'rods' | iinit
 echo 'Authenticated as rods'
+iadmin mkuser testuser rodsuser
 
 cd /ibridges/integration_test
 pytest .

--- a/docker/irods_client/entrypoint.sh
+++ b/docker/irods_client/entrypoint.sh
@@ -27,5 +27,4 @@ echo "iRODS is ready"
 
 cd /ibridges/integration_test
 pytest .
-
-bash -c "until false; do sleep 2147483647d; done"
+/bin/bash

--- a/docker/irods_client/tests/test_permissions.py
+++ b/docker/irods_client/tests/test_permissions.py
@@ -22,20 +22,14 @@ def test_permissions(session, item_name, request, tmpdir):
         upload(session, tmpdir/"bunny.rt.copy", ipath, overwrite=True)
     perm.set("own")
 
-    # TODO: Add more tests with other users.
+    # Testing access for another user
 
-    # assert len(list(perm)) == 0
-    # ipath = IrodsPath(session, item.path)
-    # with pytest.raises(CAT_NO_ACCESS_PERMISSION):
-    #     download(session, ipath, tmpdir/"bunny.rt.copy", overwrite=True)
-    # perm.set("read", user=session.username, zone=session.zone)
-    # download(session, ipath, tmpdir/"bunny.rt.copy", overwrite=True)
-    # assert (tmpdir/"bunny.rt.copy").is_file
-    # with pytest.raises(ValueError):
-    #     upload(session, tmpdir/"bunny.rt.copy", ipath, overwrite=True)
-    # perm.set("write", user=session.username, zone=session.zone)
-    # # if item_name == "dataobject":
-    # upload(session, tmpdir/"bunny.rt.copy", ipath, overwrite=True)
-    # # else:
-    #     # upload(session, tmpdir/"bunny.rt.copy", ipath, overwrite=True)
-    # assert ipath.is_dataobject()
+    assert len(list(perm)) == 1 # only one acl for rods
+    ipath = IrodsPath(session, item.path)
+    perm.set("read", user="testuser", zone=session.zone)
+    assert "testuser" in [p.user_name for p in perm]
+    assert ("testuser", "read_object") in [(p.user_name, p.access_name) for p in perm]
+    perm.set("write", user="testuser", zone=session.zone)
+    assert ("testuser", "modify_object") in [(p.user_name, p.access_name) for p in perm]
+    perm.set("null", user="testuser", zone=session.zone)
+    assert "testuser" not in [p.user_name for p in perm]

--- a/docker/irods_client/tests/test_session_cached_pw.py
+++ b/docker/irods_client/tests/test_session_cached_pw.py
@@ -1,0 +1,15 @@
+import os
+from ibridges import Session
+
+def test_session_from_cached_pw(config, irods_env):
+    session = Session(irods_env_path=os.path.expanduser("~/.irods/irods_environment.json"))
+    assert session.has_valid_irods_session()
+    assert ".".join(str(x) for x in session.server_version) == config["server_version"]
+    assert session.home == irods_env["irods_home"]
+    assert session.default_resc == irods_env["irods_default_resource"]
+    assert session.host == irods_env["irods_host"]
+    assert session.port == irods_env["irods_port"]
+    assert session.username == irods_env["irods_user_name"]
+    assert session.zone == irods_env["irods_zone_name"]
+
+    del session


### PR DESCRIPTION
**Fixed icommands**
- irods_environment.json is no places in /root/.irods/irods_environment.json
- `iinit` is done; this also caches a password in /root/.irods/.irodsA

**Session**
- Adds  a test that checks whether a session can be created from the /root/.irods/environment.json and the cached password

**Permissions**
- The entrypoint now creates a second user `testuser`
- Extends the permissions tests with setting and withdrawing access for the `testuser`