### PR TITLE
Fix gitattributes so that the files are not binary

### DIFF
--- a/docker/.gitattributes
+++ b/docker/.gitattributes
@@ -1,6 +1,6 @@
 # source: https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings
 # Set the default behavior, in case people don't have core.autocrlf set.
-* binary
+# * binary
 
 # Explicitly declare text files you want to always be normalized and converted
 # to native line endings on checkout.


### PR DESCRIPTION
@chStaiger I think I just got the gitattributes file from your repo. Is there any reason to have git consider everything as a binary? I now understand why I couldn't rebase properly last time...