### PR TITLE
72 export metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # iBridges
+[![PyPI version](https://badge.fury.io/py/ibridges.svg)](https://badge.fury.io/py/ibridges)
 [![](https://github.com/UtrechtUniversity/iBridges/actions/workflows/integration-tests-irods.yml/badge.svg?branch=develop)](https://github.com/UtrechtUniversity/iBridges/actions/workflows/integration-tests-irods.yml) [![](https://github.com/UtrechtUniversity/iBridges/actions/workflows/main.yml/badge.svg?branch=develop)](https://github.com/UtrechtUniversity/iBridges/actions/workflows/main.yml) 
 [![](https://github.com/UtrechtUniversity/iBridges/actions/workflows/integration-tests-yoda.yml/badge.svg)](https://github.com/UtrechtUniversity/iBridges/actions/workflows/integration-tests-yoda.yml) ![](https://readthedocs.org/projects/ibridges/badge/?version=latest&style=flat-default)
 

--- a/docker/irods_client/tests/test_meta.py
+++ b/docker/irods_client/tests/test_meta.py
@@ -1,8 +1,9 @@
 import pytest
 from pytest import mark
+import irods
 
 from ibridges.meta import MetaData
-
+from ibridges.export_metadata import export_metadata_to_dict
 
 @mark.parametrize("item_name", ["collection", "dataobject"])
 def test_meta(item_name, request):
@@ -61,3 +62,29 @@ def test_meta(item_name, request):
     assert "x" in meta
     assert ("y", "z") not in meta
     assert ("y", "x") in meta
+
+@mark.parametrize("item_name", ["collection", "dataobject"])
+def test_export_metadata(item_name, request):
+    item = request.getfixturevalue(item_name)
+    meta = MetaData(item)
+    meta.clear()
+    
+    # test against:
+    test_dict = {
+            'name': item.name,
+            'irods_id': item.id,
+            'metadata': [('x', 'z', 'm')]
+            }
+
+    if isinstance(item, irods.data_object.iRODSDataObject):
+        test_dict['checksum'] = item.checksum
+    
+    # Add some metadata
+    meta.add("x", "z", "m")
+    assert "x" in meta
+    result = meta.to_dict()
+
+    for key in result.keys():
+        assert key in test_dict
+    for value in result.values():
+        assert value in test_dict.values()

--- a/ibridges/export_metadata.py
+++ b/ibridges/export_metadata.py
@@ -49,12 +49,12 @@ def export_metadata_to_dict(meta: MetaData, session: Session,
         ]
     }
     """
+    version = {"ibridges_metadata_version": 1.0}
     if is_dataobject(meta.item):
-        return meta.to_dict(keys = keys)
+        return version | meta.to_dict(keys = keys)
     if is_collection(meta.item):
-        metadata_dict = meta.to_dict(keys = keys)
+        metadata_dict = version | meta.to_dict(keys = keys)
         if recursive is True:
-            metadata_dict["ibridges_metadata_version"] = "1.0"
             objects, collections = get_meta_from_irods_tree(session, meta.item,
                                                             root = meta.item.path)
             metadata_dict["subcollections"] = collections

--- a/ibridges/export_metadata.py
+++ b/ibridges/export_metadata.py
@@ -1,29 +1,32 @@
-from ibridges.data_operations import is_collection, is_dataobject
-from ibridges.data_operations import get_collection, get_dataobject
-from ibridges.meta import MetaData
-from ibridges.path import IrodsPath
+"""Exporting metadata.
+"""
 
-from ibridges import keywords as kw
-from ibridges.session import Session
 from typing import Optional
 
-def export_metadata_to_dict(meta: MetaData, session: Session, 
-            recursive: bool = True, keys: Optional[list] = None) -> dict:
+from ibridges.data_operations import is_collection, is_dataobject
+from ibridges.meta import MetaData
+from ibridges.path import IrodsPath
+from ibridges.session import Session
+
+def export_metadata_to_dict(meta: MetaData, session: Session,
+                            recursive: bool = True, keys: Optional[list] = None) -> dict:
     """Retrieves the metadata of the item and brings it into dict form.
     If the item is a collection all metadata from all subcollections
     and data objects will also be exported.
 
     {
-        "rel_path": name
-        "checksum": <checksum if data object>
+        "name": name
+        "irods_id": iRODS database ID
         "metadata": [(key, val, units), (key, val, units) ….]
         "collections”: [ # only if collection and recursive == True
             {
                 "rel_path": relative path to upper rel_path
+                "irods_id": iRODS database ID
                 "metadata": [(key, val, units), (key, val, units) ….]
             },
             {
                 "rel_path": relative path to upper rel_path
+                "irods_id": iRODS database ID
                 "metadata": [(key, val, units), (key, val, units) ….]
             },
             …
@@ -31,11 +34,13 @@ def export_metadata_to_dict(meta: MetaData, session: Session,
         "data_objects":[ # only if collection and recurisve == True
             {
                 "rel_path": relative path to upper rel_path
+                "irods_id": iRODS database ID
                 "checksum": <checksum>
                 "metadata": [(key, val, units), (key, val, units) ….]
             },
             {
                 "rel_path": relative path to upper rel_path
+                "irods_id": iRODS database ID
                 "checksum": <checksum>
                 "metadata": [(key, val, units), (key, val, units) ….]
             },
@@ -45,19 +50,19 @@ def export_metadata_to_dict(meta: MetaData, session: Session,
     """
     if is_dataobject(meta.item):
         return meta.to_dict(keys = keys)
-    elif is_collection(meta.item):
+    if is_collection(meta.item):
         metadata_dict = meta.to_dict(keys = keys)
-        if recursive == True:
-            objects, collections = get_subcolls(session, meta.item, root = meta.item.path) 
+        if recursive is True:
+            objects, collections = get_subcolls(session, meta.item, root = meta.item.path)
             metadata_dict["subcollections"] = collections
             metadata_dict["dataobjects"] = objects
             return metadata_dict
-        else:
-            return metadata_dict
-    else:
-        raise ValueError("Not a data collection or data object: {item}")
+        return metadata_dict
+    raise ValueError("Not a data collection or data object: {item}")
 
 def get_subcolls(session, coll, root: Optional[IrodsPath] = None):
+    """Recursively gather the metadata for all subcollections and data objects.
+    """
     if root is not None:
         coll_path = IrodsPath(session, root)
     else:
@@ -82,4 +87,3 @@ def get_subcolls(session, coll, root: Optional[IrodsPath] = None):
         collections = []
 
     return objects, collections
-

--- a/ibridges/export_metadata.py
+++ b/ibridges/export_metadata.py
@@ -70,13 +70,13 @@ def get_subcolls(session, coll, root: Optional[IrodsPath] = None):
     objects = [{'name': o.name, 'irods_id': o.id,
                 'rel_path': '/'.join(IrodsPath(session, 
                                                o.path).parts[len(coll_path.parts):]),
-                'metadata': MetaData(o).to_dict()}
+                'metadata': MetaData(o).to_dict()['metadata']}
                 for o in coll.data_objects
                ]
     collections = [{'name': c.name, 'irods_id': c.id,
                     'rel_path': '/'.join(IrodsPath(session,
                                                c.path).parts[len(coll_path.parts):]),
-                    'metadata': MetaData(c).to_dict()}
+                    'metadata': MetaData(c).to_dict()['metadata']}
                     for c in coll.subcollections]
     if len(coll.subcollections) > 0:
         for subcoll in coll.subcollections:

--- a/ibridges/export_metadata.py
+++ b/ibridges/export_metadata.py
@@ -1,0 +1,86 @@
+from ibridges.data_operations import is_collection, is_dataobject
+from ibridges.data_operations import get_collection, get_dataobject
+from ibridges.data_operations import _get_data_objects
+from ibridges.meta import MetaData
+
+from ibridges import keywords as kw
+from ibridges.session import Session
+
+def obj_meta_to_dict(meta: MetaData, keys: Optional[list] = None) -> dict:
+    """Returns the metadata of an object as a dictionary. Adds the checksum
+    {"checksum": <checksum>
+     "metadata": [(key1, value1, units1), (key2, value2, units2) ...]
+    }
+    """
+    meta = {}
+    meta["checksum"] = self.item.checksum
+    if keys is None:
+        meta["Metadata"] = [(m.name, m.value, m.units) for m in self]
+    else:
+        meta["Metadata"] = [(m.name, m.value, m.units) for m in self if m.name in keys]
+    return meta
+
+def coll_meta_to_dict(meta: MetaData, keys: Optional[list] = None) -> dict:
+    """Returns the metadata of an object as a dictionary.
+    {
+     "metadata": [(key1, value1, units1), (key2, value2, units2) ...]
+    }
+    """
+    meta = {}
+    if keys is None:
+        meta["Metadata"] = [(m.name, m.value, m.units) for m in self]
+    else:
+        meta["Metadata"] = [(m.name, m.value, m.units) for m in self if m.name in keys]
+    return meta
+def to_dict(meta: MetaData, session: Session, 
+            recursive: bool = True, keys: Optional[list] = None) -> dict:
+    """Retrieves the metadata of the item and brings it into dict form.
+    If the item is a collection all metadata from all subcollections
+    and data objects will also be exported.
+
+    {
+        "rel_path": name
+        "checksum": <checksum if data object>
+        "metadata": [(key, val, units), (key, val, units) ….]
+        "collections”: [ # only if collection and recursive == True
+            {
+                "rel_path": relative path to upper rel_path
+                "metadata": [(key, val, units), (key, val, units) ….]
+            },
+            {
+                "rel_path": relative path to upper rel_path
+                "metadata": [(key, val, units), (key, val, units) ….]
+            },
+            …
+        ]
+        "data_objects":[ # only if collection and recurisve == True
+            {
+                "rel_path": relative path to upper rel_path
+                "checksum": <checksum>
+                "metadata": [(key, val, units), (key, val, units) ….]
+            },
+            {
+                "rel_path": relative path to upper rel_path
+                "checksum": <checksum>
+                "metadata": [(key, val, units), (key, val, units) ….]
+            },
+            …
+        ]
+    }
+    """
+    meta_dict = {"rel_path": self.item.name}
+    if is_dataobject(self.item):
+        meta_dict.update(self.obj_meta_to_dict(keys = keys))
+        return meta_dict
+    elif is_collection(self.item):
+        meta_dict.update(self.coll_meta_to_dict(keys = keys))
+        if recursive == True:
+            # get all data objects and their metadata
+            objs = [get_dataobject(session, path+'/'+name)
+                    for path, name, _, _ in _get_data_objects(session, coll)]
+
+            print("collection")
+        else:
+            return meta_dict
+    else:
+        raise ValueError("Not a data collection or data object: {item}")

--- a/ibridges/export_metadata.py
+++ b/ibridges/export_metadata.py
@@ -54,6 +54,7 @@ def export_metadata_to_dict(meta: MetaData, session: Session,
     if is_collection(meta.item):
         metadata_dict = meta.to_dict(keys = keys)
         if recursive is True:
+            metadata_dict["ibridges_metadata_version"] = "1.0"
             objects, collections = get_meta_from_irods_tree(session, meta.item,
                                                             root = meta.item.path)
             metadata_dict["subcollections"] = collections

--- a/ibridges/meta.py
+++ b/ibridges/meta.py
@@ -3,8 +3,7 @@ from typing import Iterator, Optional, Sequence, Union
 
 import irods.exception
 import irods.meta
-
-from ibridges.data_operations import is_collection, is_dataobject
+from ibridges.data_operations import is_dataobject
 
 class MetaData():
     """Irods metadata operations."""
@@ -53,8 +52,8 @@ class MetaData():
         meta_list = sorted(meta_list, key=lambda m: (m.value is None, m.value))
         meta_list = sorted(meta_list, key=lambda m: (m.name is None, m.name))
         meta_str = ""
-        for m in meta_list:
-            meta_str += f" - {{name: {m.name}, value: {m.value}, units: {m.units}}}\n"
+        for meta in meta_list:
+            meta_str += f" - {{name: {meta.name}, value: {meta.value}, units: {meta.units}}}\n"
         return meta_str
 
     def add(self, key: str, value: str, units: Optional[str] = None):
@@ -144,7 +143,22 @@ class MetaData():
         for meta in self:
             self.item.metadata.remove(meta)
 
-    def to_dict(self, keys: Optional[list] = None):
+    def to_dict(self, keys: Optional[list] = None) -> dict:
+        """Converts iRODS metadata (AVUs) and system information to a python dictionary.
+        {
+            "name": item.name,
+            "irods_id": item.id, #iCAT database ID
+             "checksum": item.checksum if the item is a data object
+             "metadata": [(m.name, m.value, m.units)]
+        }
+
+        Parameters
+        ----------
+        keys:
+            List of Attribute names which should be exported to "metadata". 
+            By default all will be exported.
+           
+        """
         meta_dict = {}
         meta_dict["name"] = self.item.name
         meta_dict["irods_id"] = self.item.id
@@ -154,5 +168,4 @@ class MetaData():
             meta_dict["metadata"] = [(m.name, m.value, m.units) for m in self]
         else:
             meta_dict["metadata"] = [(m.name, m.value, m.units) for m in self if m.name in keys]
-        
         return meta_dict

--- a/ibridges/meta.py
+++ b/ibridges/meta.py
@@ -160,6 +160,7 @@ class MetaData():
            
         """
         meta_dict = {}
+        meta_dict["ibridges_metadata_version"] = "1.0"
         meta_dict["name"] = self.item.name
         meta_dict["irods_id"] = self.item.id
         if is_dataobject(self.item):

--- a/ibridges/meta.py
+++ b/ibridges/meta.py
@@ -160,7 +160,6 @@ class MetaData():
            
         """
         meta_dict = {}
-        meta_dict["ibridges_metadata_version"] = "1.0"
         meta_dict["name"] = self.item.name
         meta_dict["irods_id"] = self.item.id
         if is_dataobject(self.item):

--- a/ibridges/meta.py
+++ b/ibridges/meta.py
@@ -4,6 +4,7 @@ from typing import Iterator, Optional, Sequence, Union
 import irods.exception
 import irods.meta
 
+from ibridges.data_operations import is_collection, is_dataobject
 
 class MetaData():
     """Irods metadata operations."""
@@ -142,3 +143,16 @@ class MetaData():
         """Delete all metadata belonging to the item."""
         for meta in self:
             self.item.metadata.remove(meta)
+
+    def to_dict(self, keys: Optional[list] = None):
+        meta_dict = {}
+        meta_dict["name"] = self.item.name
+        meta_dict["irods_id"] = self.item.id
+        if is_dataobject(self.item):
+            meta_dict["checksum"] = self.item.checksum
+        if keys is None:
+            meta_dict["metadata"] = [(m.name, m.value, m.units) for m in self]
+        else:
+            meta_dict["metadata"] = [(m.name, m.value, m.units) for m in self if m.name in keys]
+        
+        return meta_dict


### PR DESCRIPTION
- Extended meta.py with function that exports some system metadata and user metadata as python dictionary
- Added a function that iterates over a whole collection and exports all metadata of the collection, its subcollections and all data objects as python dictionary.

Dictionary structure:
```
{
'name': name, 
'irods_id': id,
'metadata': [(avu1), (avu2), ...],
'subcollections':[
    {'name': name, 
     'irods_id': id,
      'rel_path': relative path to the parent collection #recursive export,
      'metadata': [(avu1), (avu2), ...]
    }, 
    ...
]
'dataobjects':[{
    'name': name, 
    'irods_id': id,
    'rel_path': relative path to the parent collection #recursive export,
    'checksum': object checksum
    'metadata': [(avu1), (avu2), ...]
   },
  ...
  ]
}
```
