### PR TITLE
Improving the error when upload or download fails

### DIFF
--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -227,7 +227,7 @@ def _upload_collection(session: Session, local_path: Union[str, Path],
     overwrite : bool
         If data already exists on iRODS, overwrite
     ignore_err : bool
-        ignore failure on current item and continue to next one     
+        If an error occurs during upload, and ignore_err is set to True, any errors encountered will be transformed into warnings and iBridges will continue to upload the remaining files. By default all errors will stop the process of uploading.
     resc_name : str
         Name of the resource to which data is uploaded, by default the server will decide
     options : dict

--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -245,7 +245,7 @@ def _upload_collection(session: Session, local_path: Union[str, Path],
             _obj_put(session, source, dest, overwrite, resc_name, options)
         except irods.exception.OVERWRITE_WITHOUT_FORCE_FLAG:
             warnings.warn(f'Upload: Object already exists\n\tSkipping {source}')
-        except Exception as e:
+        except KeyError as e:
             warnings.warn(f'Upload failed: {source}\n'+repr(e))
 
 def _create_local_dest(session: Session, irods_path: IrodsPath, local_path: Path
@@ -297,7 +297,7 @@ def _download_collection(session: Session, irods_path: Union[str, IrodsPath], lo
             _obj_get(session, source, dest, overwrite, options)
         except irods.exception.OVERWRITE_WITHOUT_FORCE_FLAG:
             warnings.warn(f'Download: File already exists\n\tSkipping {source}')
-        except Exception as e:
+        except KeyError as e:
             warnings.warn(f'Download failed: {source}i\n'+repr(e))
 
 def upload(session: Session, local_path: Union[str, Path], irods_path: Union[str, IrodsPath],

--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -248,7 +248,7 @@ def _upload_collection(session: Session, local_path: Union[str, Path],
         try:
             _obj_put(session, source, dest, overwrite, resc_name, options)
         except irods.exception.OVERWRITE_WITHOUT_FORCE_FLAG:
-            warnings.warn(f'Upload: Object already exists\n\tSkipping {source}')
+            warnings.warn(f'Object already exists\tSkipping {source}')
         except KeyError as e:
             if ignore_err is True:
                 warnings.warn(f'Upload failed: {source}\n'+repr(e))
@@ -309,7 +309,7 @@ def _download_collection(session: Session, irods_path: Union[str, IrodsPath], lo
         try:
             _obj_get(session, source, dest, overwrite, options)
         except irods.exception.OVERWRITE_WITHOUT_FORCE_FLAG:
-            warnings.warn(f'Download: File already exists\n\tSkipping {source}')
+            warnings.warn(f'File already exists\tSkipping {source}')
         except KeyError as e:
             if ignore_err is True:
                 warnings.warn(f'Download failed: {source}i\n'+repr(e))

--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -253,8 +253,7 @@ def _upload_collection(session: Session, local_path: Union[str, Path],
             if ignore_err is True:
                 warnings.warn(f'Upload failed: {source}\n'+repr(e))
             else:
-                print(f'Upload failed: {source}')
-                raise e
+                raise ValueError(f'Upload failed: {source}: '+repr(e)) from e
 
 def _create_local_dest(session: Session, irods_path: IrodsPath, local_path: Path
                        ) -> list[tuple[IrodsPath, Path]]:
@@ -290,7 +289,8 @@ def _download_collection(session: Session, irods_path: Union[str, IrodsPath], lo
         Overwrite existing local data
     ignore_err : bool
         If an error occurs during download, and ignore_err is set to True, any errors encountered
-        will be transformed into warnings and iBridges will continue to download the remaining files.
+        will be transformed into warnings and iBridges will continue to download the remaining
+        files.
         By default all errors will stop the process of uploading.
     options : dict
         More options for the download
@@ -314,8 +314,7 @@ def _download_collection(session: Session, irods_path: Union[str, IrodsPath], lo
             if ignore_err is True:
                 warnings.warn(f'Download failed: {source}i\n'+repr(e))
             else:
-                print(f'Download failed: {source}')
-                raise e
+                raise ValueError(f'Download failed: {source}: '+repr(e)) from e
 
 def upload(session: Session, local_path: Union[str, Path], irods_path: Union[str, IrodsPath],
            overwrite: bool = False, ignore_err: bool = False,
@@ -374,7 +373,8 @@ def download(session: Session, irods_path: Union[str, IrodsPath], local_path: Un
         Absolute path to the destination directory
     overwrite : bool
         If an error occurs during download, and ignore_err is set to True, any errors encountered
-        will be transformed into warnings and iBridges will continue to download the remaining files.
+        will be transformed into warnings and iBridges will continue to download the remaining
+        files.
         By default all errors will stop the process of downloading.
     ignore_err : bool
         Collections: If download of an item fails print error and continue with next item.

--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -245,6 +245,9 @@ def _upload_collection(session: Session, local_path: Union[str, Path],
             _obj_put(session, source, dest, overwrite, resc_name, options)
         except irods.exception.OVERWRITE_WITHOUT_FORCE_FLAG:
             warnings.warn(f'Upload: Object already exists\n\tSkipping {source}')
+        except Exception as e:
+            warnings.warn(f'Upload failed: {source}')
+            raise e
 
 def _create_local_dest(session: Session, irods_path: IrodsPath, local_path: Path
                        ) -> list[tuple[IrodsPath, Path]]:
@@ -295,6 +298,9 @@ def _download_collection(session: Session, irods_path: Union[str, IrodsPath], lo
             _obj_get(session, source, dest, overwrite, options)
         except irods.exception.OVERWRITE_WITHOUT_FORCE_FLAG:
             warnings.warn(f'Download: File already exists\n\tSkipping {source}')
+        except Exception as e:
+            warnings.warn(f'Download failed: {source}')
+            raise e
 
 def upload(session: Session, local_path: Union[str, Path], irods_path: Union[str, IrodsPath],
            overwrite: bool = False, resc_name: str = '', options: Optional[dict] = None):

--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -227,7 +227,9 @@ def _upload_collection(session: Session, local_path: Union[str, Path],
     overwrite : bool
         If data already exists on iRODS, overwrite
     ignore_err : bool
-        If an error occurs during upload, and ignore_err is set to True, any errors encountered will be transformed into warnings and iBridges will continue to upload the remaining files. By default all errors will stop the process of uploading.
+        If an error occurs during upload, and ignore_err is set to True, any errors encountered
+        will be transformed into warnings and iBridges will continue to upload the remaining files.
+        By default all errors will stop the process of uploading.
     resc_name : str
         Name of the resource to which data is uploaded, by default the server will decide
     options : dict
@@ -287,7 +289,9 @@ def _download_collection(session: Session, irods_path: Union[str, IrodsPath], lo
     overwrite : bool
         Overwrite existing local data
     ignore_err : bool
-        Ignore failure on current item and continue to next one
+        If an error occurs during download, and ignore_err is set to True, any errors encountered
+        will be transformed into warnings and iBridges will continue to download the remaining files.
+        By default all errors will stop the process of uploading.
     options : dict
         More options for the download
 
@@ -329,7 +333,9 @@ def upload(session: Session, local_path: Union[str, Path], irods_path: Union[str
     overwrite : bool
         If data object or collection already exists on iRODS, overwrite
     ignore_err : bool
-        Collections: If upload of an item fails print error and continue with next item.
+        If an error occurs during upload, and ignore_err is set to True, any errors encountered
+        will be transformed into warnings and iBridges will continue to upload the remaining files.
+        By default all errors will stop the process of uploading.
     resc_name : str
         Name of the resource to which data is uploaded, by default the server will decide
     options : dict
@@ -367,7 +373,9 @@ def download(session: Session, irods_path: Union[str, IrodsPath], local_path: Un
     local_path : Path
         Absolute path to the destination directory
     overwrite : bool
-        Overwrite existing local data
+        If an error occurs during download, and ignore_err is set to True, any errors encountered
+        will be transformed into warnings and iBridges will continue to download the remaining files.
+        By default all errors will stop the process of downloading.
     ignore_err : bool
         Collections: If download of an item fails print error and continue with next item.
     options : dict

--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -246,8 +246,7 @@ def _upload_collection(session: Session, local_path: Union[str, Path],
         except irods.exception.OVERWRITE_WITHOUT_FORCE_FLAG:
             warnings.warn(f'Upload: Object already exists\n\tSkipping {source}')
         except Exception as e:
-            warnings.warn(f'Upload failed: {source}')
-            raise e
+            warnings.warn(f'Upload failed: {source}\n'+repr(e))
 
 def _create_local_dest(session: Session, irods_path: IrodsPath, local_path: Path
                        ) -> list[tuple[IrodsPath, Path]]:
@@ -299,8 +298,7 @@ def _download_collection(session: Session, irods_path: Union[str, IrodsPath], lo
         except irods.exception.OVERWRITE_WITHOUT_FORCE_FLAG:
             warnings.warn(f'Download: File already exists\n\tSkipping {source}')
         except Exception as e:
-            warnings.warn(f'Download failed: {source}')
-            raise e
+            warnings.warn(f'Download failed: {source}i\n'+repr(e))
 
 def upload(session: Session, local_path: Union[str, Path], irods_path: Union[str, IrodsPath],
            overwrite: bool = False, resc_name: str = '', options: Optional[dict] = None):

--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -248,8 +248,9 @@ def _upload_collection(session: Session, local_path: Union[str, Path],
         except irods.exception.OVERWRITE_WITHOUT_FORCE_FLAG:
             warnings.warn(f'Upload: Object already exists\n\tSkipping {source}')
         except KeyError as e:
-            warnings.warn(f'Upload failed: {source}\n'+repr(e))
-            if not ignore_err:
+            if ignore_err is True:
+                warnings.warn(f'Upload failed: {source}\n'+repr(e))
+            else:
                 raise e
 
 def _create_local_dest(session: Session, irods_path: IrodsPath, local_path: Path
@@ -305,8 +306,9 @@ def _download_collection(session: Session, irods_path: Union[str, IrodsPath], lo
         except irods.exception.OVERWRITE_WITHOUT_FORCE_FLAG:
             warnings.warn(f'Download: File already exists\n\tSkipping {source}')
         except KeyError as e:
-            warnings.warn(f'Download failed: {source}i\n'+repr(e))
-            if not ignore_err:
+            if ignore_err is True:
+                warnings.warn(f'Download failed: {source}i\n'+repr(e))
+            else:
                 raise e
 
 def upload(session: Session, local_path: Union[str, Path], irods_path: Union[str, IrodsPath],

--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -251,6 +251,7 @@ def _upload_collection(session: Session, local_path: Union[str, Path],
             if ignore_err is True:
                 warnings.warn(f'Upload failed: {source}\n'+repr(e))
             else:
+                print(f'Upload failed: {source}')
                 raise e
 
 def _create_local_dest(session: Session, irods_path: IrodsPath, local_path: Path
@@ -309,6 +310,7 @@ def _download_collection(session: Session, irods_path: Union[str, IrodsPath], lo
             if ignore_err is True:
                 warnings.warn(f'Download failed: {source}i\n'+repr(e))
             else:
+                print(f'Download failed: {source}')
                 raise e
 
 def upload(session: Session, local_path: Union[str, Path], irods_path: Union[str, IrodsPath],

--- a/ibridges/sync.py
+++ b/ibridges/sync.py
@@ -315,7 +315,8 @@ def _copy_local_to_irods(session: Session,
             upload(session=session,
                     local_path=source_path,
                     irods_path=target_path,
-                    overwrite=True)
+                    overwrite=True,
+                    ignore_err=True)
             obj=get_dataobject(session, target_path)
             if file.checksum != \
                     (obj.checksum if obj.checksum is not None and len(obj.checksum)>0
@@ -347,7 +348,8 @@ def _copy_irods_to_local(session: Session,
             download(session=session,
                         irods_path=source_path,
                         local_path=target_path,
-                        overwrite=True)
+                        overwrite=True,
+                        ignore_err=True)
             if obj.checksum != _calc_checksum(target_path):
                 raise ValueError(f"Checksum mismatch after download: '{source_path}'")
 

--- a/tutorials/Data_sync.ipynb
+++ b/tutorials/Data_sync.ipynb
@@ -71,7 +71,7 @@
    "outputs": [],
    "source": [
     "target = IrodsPath(session, \"~\", \"<irods path>\")\n",
-    "source = Path(os.path.expanduser(\"~\"), \"local path\")"
+    "source = Path(os.path.expanduser(\"~\"), \"<local path>\")"
    ]
   },
   {
@@ -130,8 +130,8 @@
    "source": [
     "changes = sync_data(\n",
     "    session=session,\n",
-    "    source=target,\n",
-    "    target=source,\n",
+    "    source=source,\n",
+    "    target=target,\n",
     "    max_level=max_level,      \n",
     "    dry_run=dry_run,\n",
     "    copy_empty_folders=copy_empty_folders\n",


### PR DESCRIPTION
**Catching all errors in `_download_collection` and `_upload_collection`**
- The local upload path or the irods download path on which the operation fails will be printed
- The representation of the error will be printed
- The iteration over the collection will continue