### PR TITLE
updated toml to allow newer python irods client versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "python-irodsclient==1.1.6",
+    "python-irodsclient>=1.1.6",
     "tqdm",
 ]
 


### PR DESCRIPTION
When testing with iBridges I ran into some already solved python_irodsclient bugs.
This let me to discover that the version was fixed to 1.1.6 in the iBridges toml file.

A brief chat with Christine confirmed the tests where ran agains python_irodsclient v2.0 
I updated the toml, build the package locally. It now build against python_irodsclient v2.0.0
