### PR TITLE
generalizing rules

### DIFF
--- a/ibridges/rules.py
+++ b/ibridges/rules.py
@@ -7,7 +7,10 @@ import irods.rule
 from ibridges.session import Session
 
 
-def execute_rule(session: Session, rule_file: str = '', **kwargs) -> tuple:
+def execute_rule(session: Session,
+                 output: str  = 'ruleExecOut', 
+                 instance_name: str = 'irods_rule_engine_plugin-irods_rule_language-instance', 
+                 **kwargs) -> tuple:
     """Execute an iRODS rule.
 
     params format example:
@@ -22,18 +25,13 @@ def execute_rule(session: Session, rule_file: str = '', **kwargs) -> tuple:
     ----------
     session : ibridges.session
         The irods session
-    rule_file : str
-        Name of the iRODS rule file, or a file-like object representing it.
-    kwargs : dict example keywords:
-        body    : str,rulename
-            Name of the rule on the irods server.
-        params : dict
-            Rule arguments.
-        instance_name : str
-            changes between irods rule language and python rules.
-        output : str
-            Rule output variable(s).
-
+    instance_name : str
+        changes between irods rule language and python rules.
+    output : str
+        Rule output variable(s).
+    kwargs : dict
+        optional irods rule parameters.
+        For more information: https://github.com/irods/python-irodsclient
 
     Returns
     -------
@@ -41,14 +39,10 @@ def execute_rule(session: Session, rule_file: str = '', **kwargs) -> tuple:
         (stdout, stderr)
 
     """
-    if 'output' not in kwargs:
-        kwargs['output'] = 'ruleExecOut'
-    if 'instance_name' not in kwargs:
-        kwargs['instance_name'] = 'irods_rule_engine_plugin-irods_rule_language-instance'
-
     try:
         rule = irods.rule.Rule(
-            session.irods_session, rule_file=rule_file, **kwargs)
+            session.irods_session, instance_name=instance_name,
+            output=output, **kwargs)
         out = rule.execute()
     except irods.exception.NetworkException as error:
         logging.info('Lost connection to iRODS server.')

--- a/ibridges/rules.py
+++ b/ibridges/rules.py
@@ -7,7 +7,7 @@ import irods.rule
 from ibridges.session import Session
 
 
-def execute_rule(session: Session, rule_file: str = None, **kwargs) -> tuple:
+def execute_rule(session: Session, rule_file: str = '', **kwargs) -> tuple:
     """Execute an iRODS rule.
 
     params format example:

--- a/ibridges/rules.py
+++ b/ibridges/rules.py
@@ -1,6 +1,6 @@
 """Rule operations."""
 import logging
-
+from typing import Optional
 import irods.exception
 import irods.rule
 
@@ -8,6 +8,8 @@ from ibridges.session import Session
 
 
 def execute_rule(session: Session,
+                 rule_file: Optional[str],
+                 params: Optional[dict],
                  output: str = 'ruleExecOut',
                  instance_name: str = 'irods_rule_engine_plugin-irods_rule_language-instance',
                  **kwargs) -> tuple:
@@ -25,10 +27,14 @@ def execute_rule(session: Session,
     ----------
     session : ibridges.session
         The irods session
-    instance_name : str
-        changes between irods rule language and python rules.
+    rule_file : str
+        Name of the iRODS rule file, or a file-like object representing it.
+    params: dict
+        Rule input variable(s).
     output : str
         Rule output variable(s).
+    instance_name : str
+        Changes between irods rule language and python rules.
     kwargs : dict
         optional irods rule parameters.
         For more information: https://github.com/irods/python-irodsclient
@@ -41,7 +47,10 @@ def execute_rule(session: Session,
     """
     try:
         rule = irods.rule.Rule(
-            session.irods_session, instance_name=instance_name,
+            session.irods_session,
+            rule_file=rule_file,
+            params=params,
+            instance_name=instance_name,
             output=output, **kwargs)
         out = rule.execute()
     except irods.exception.NetworkException as error:

--- a/ibridges/rules.py
+++ b/ibridges/rules.py
@@ -7,7 +7,7 @@ import irods.rule
 from ibridges.session import Session
 
 
-def execute_rule(session: Session, rule_file: str = None, body: str = '', params: dict = {},
+def execute_rule(session: Session, rule_file: str = None, body: str = '', params: dict = None,
                  rule_type: str = 'irods_rule_language', output: str = 'ruleExecOut') -> tuple:
     """Execute an iRODS rule.
 

--- a/ibridges/rules.py
+++ b/ibridges/rules.py
@@ -7,8 +7,7 @@ import irods.rule
 from ibridges.session import Session
 
 
-def execute_rule(session: Session, rule_file: str = None, body: str = '', params: dict = None,
-                 rule_type: str = 'irods_rule_language', output: str = 'ruleExecOut') -> tuple:
+def execute_rule(session: Session, rule_file: str = None, **kwargs) -> tuple:
     """Execute an iRODS rule.
 
     params format example:
@@ -25,14 +24,16 @@ def execute_rule(session: Session, rule_file: str = None, body: str = '', params
         The irods session
     rule_file : str
         Name of the iRODS rule file, or a file-like object representing it.
-    body    : str,rulename
-        Name of the rule on the irods server.
-    params : dict
-        Rule arguments.
-    rule_type : str
-        changes between irods rule language and python rules.
-    output : str
-        Rule output variable(s).
+    kwargs : dict example keywords:
+        body    : str,rulename
+            Name of the rule on the irods server.
+        params : dict
+            Rule arguments.
+        instance_name : str
+            changes between irods rule language and python rules.
+        output : str
+            Rule output variable(s).
+
 
     Returns
     -------
@@ -40,10 +41,14 @@ def execute_rule(session: Session, rule_file: str = None, body: str = '', params
         (stdout, stderr)
 
     """
+    if 'output' not in kwargs:
+        kwargs['output'] = 'ruleExecOut'
+    if 'instance_name' not in kwargs:
+        kwargs['instance_name'] = 'irods_rule_engine_plugin-irods_rule_language-instance'
+
     try:
         rule = irods.rule.Rule(
-            session.irods_session, rule_file=rule_file, body=body, params=params, output=output,
-            instance_name=f'irods_rule_engine_plugin-{rule_type}-instance')
+            session.irods_session, rule_file=rule_file, **kwargs)
         out = rule.execute()
     except irods.exception.NetworkException as error:
         logging.info('Lost connection to iRODS server.')

--- a/ibridges/rules.py
+++ b/ibridges/rules.py
@@ -8,8 +8,8 @@ from ibridges.session import Session
 
 
 def execute_rule(session: Session,
-                 output: str  = 'ruleExecOut', 
-                 instance_name: str = 'irods_rule_engine_plugin-irods_rule_language-instance', 
+                 output: str = 'ruleExecOut',
+                 instance_name: str = 'irods_rule_engine_plugin-irods_rule_language-instance',
                  **kwargs) -> tuple:
     """Execute an iRODS rule.
 

--- a/ibridges/rules.py
+++ b/ibridges/rules.py
@@ -7,8 +7,8 @@ import irods.rule
 from ibridges.session import Session
 
 
-def execute_rule(session: Session, rule_file: str, params: dict,
-                 output: str = 'ruleExecOut') -> tuple:
+def execute_rule(session: Session, rule_file: str = None, body: str = '', params: dict = {},
+                 rule_type: str = 'irods_rule_language', output: str = 'ruleExecOut') -> tuple:
     """Execute an iRODS rule.
 
     params format example:
@@ -25,8 +25,12 @@ def execute_rule(session: Session, rule_file: str, params: dict,
         The irods session
     rule_file : str
         Name of the iRODS rule file, or a file-like object representing it.
+    body    : str,rulename
+        Name of the rule on the irods server.
     params : dict
         Rule arguments.
+    rule_type : str
+        changes between irods rule language and python rules.
     output : str
         Rule output variable(s).
 
@@ -38,8 +42,8 @@ def execute_rule(session: Session, rule_file: str, params: dict,
     """
     try:
         rule = irods.rule.Rule(
-            session.irods_session, rule_file=rule_file, params=params, output=output,
-            instance_name='irods_rule_engine_plugin-irods_rule_language-instance')
+            session.irods_session, rule_file=rule_file, body=body, params=params, output=output,
+            instance_name=f'irods_rule_engine_plugin-{rule_type}-instance')
         out = rule.execute()
     except irods.exception.NetworkException as error:
         logging.info('Lost connection to iRODS server.')

--- a/tutorials/QuickStart.ipynb
+++ b/tutorials/QuickStart.ipynb
@@ -819,7 +819,7 @@
    "source": [
     "from ibridges.rules import execute_rule\n",
     "rule_file = \"example_rules/example.r\"\n",
-    "stdout, stderr = execute_rule(session, rule_file, {})"
+    "stdout, stderr = execute_rule(session, rule_file)"
    ]
   },
   {
@@ -848,7 +848,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "std_out, std_err = execute_rule(session, body = '<Name of the Rule>', rule_type = '<type of the rule>')\n",
+    "std_out, std_err = execute_rule(session, body = '<Name of the Rule>', instance_name = '<type of the rule>')\n",
     "print(stdout)"
    ]
   },

--- a/tutorials/QuickStart.ipynb
+++ b/tutorials/QuickStart.ipynb
@@ -835,6 +835,25 @@
   },
   {
    "cell_type": "markdown",
+   "id": "0a64b6b1",
+   "metadata": {},
+   "source": [
+    "Executing a rule on the server"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6001026c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "std_out, std_err = execute_rule(session, body = '<Name of the Rule>', rule_type = '<type of the rule>')\n",
+    "print(stdout)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "97970ce3",
    "metadata": {},
    "source": [
@@ -1048,7 +1067,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
A request for two small changes in the rule engine. 
The reason for these is that at WUR we would like to run python based rules on the server. 

1. Support for different types of rules the 'irods_rule_engine_plugin-irods_rule_language-instance' is really cool. However, I hope many user, like me, will also like the 'irods_rule_engine_plugin-python-instance'. The new implementation defaults to the 'irods_rule_language', but it gives user the option to work with the other plugins.
2. Currently the rule file must be on the users machine. It would also be nice to have the ability to run rules which are available on the server. With this small change users can do both. The naming is taken from the python irods client, not saying it's the clearest.

Curious to hear what you think.

   
