### PR TITLE
Fix ibridges output for `ibridges --version`

### DIFF
--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -60,7 +60,7 @@ def main() -> None:
     if subcommand in ["-h", "--help"]:
         print(MAIN_HELP_MESSAGE)
     elif subcommand in ["-v", "--version"]:
-        print(f"Metasyn CLI version {version('metasyn')}")
+        print(f"iBridges version {version('ibridges')}")
 
     # find the subcommand in this module and run it!
     elif subcommand == "download":


### PR DESCRIPTION
It would be nice if it didn't try to output the version of metasyn..