### PR TITLE
Sync update

### DIFF
--- a/docker/irods_client/tests/test_sync.py
+++ b/docker/irods_client/tests/test_sync.py
@@ -17,7 +17,7 @@ def test_sync_dry_run(session, testdata, capsys):
                     dry_run=True,
                     copy_empty_folders=True)
 
-    assert len(ops["create_collection"]) == 0
+    assert len(ops["create_collection"]) == 1
     assert len(ops["create_dir"]) == 0
     assert len(ops["download"]) == 0
     assert len(ops["upload"]) == 7

--- a/docker/irods_client/tests/test_sync.py
+++ b/docker/irods_client/tests/test_sync.py
@@ -7,6 +7,7 @@ def test_sync_dry_run(session, testdata, capsys):
 
     ipath = IrodsPath(session, "~", "empty")
     coll = create_collection(session=session, coll_path=ipath)
+    assert len(coll.data_objects)+len(coll.subcollections)==0, "Dry run starting not empty"
 
     # upload
     ops = sync_data(session=session,
@@ -20,22 +21,8 @@ def test_sync_dry_run(session, testdata, capsys):
     assert len(ops["create_dir"]) == 0
     assert len(ops["download"]) == 0
     assert len(ops["upload"]) == 7
-
-    # captured = capsys.readouterr()
-    # lines=sorted([x.strip() for x in captured.out.split("\n") if len(x.strip())>0])
-
-    # assert lines == ['/tempZone/home/rods/empty/more_data',
-    #     'Will create collection(s):',
-    #     "Will upload from '/tmp/testdata' to '/tempZone/home/rods/empty':",
-    #     'beach.rtf  727',
-    #     'bunny.rtf  10150',
-    #     'example.r  182',
-    #     'more_data/polarbear.txt  2717',
-    #     'plant.rtf  992',
-    #     'plant.rtf.copy  992',
-    #     'sun.rtf  661']
-
     assert len(coll.data_objects)+len(coll.subcollections)==0, "Dry run did sync"
+
 
 def test_sync_upload_download(session, testdata, tmpdir):
     ipath = IrodsPath(session, "~", "empty")

--- a/docker/irods_client/tests/test_sync.py
+++ b/docker/irods_client/tests/test_sync.py
@@ -9,26 +9,31 @@ def test_sync_dry_run(session, testdata, capsys):
     coll = create_collection(session=session, coll_path=ipath)
 
     # upload
-    sync_data(session=session,
-         source=testdata,
-         target=ipath,
-         max_level=None,
-         dry_run=True,
-         copy_empty_folders=True)
+    ops = sync_data(session=session,
+                    source=testdata,
+                    target=ipath,
+                    max_level=None,
+                    dry_run=True,
+                    copy_empty_folders=True)
 
-    captured = capsys.readouterr()
-    lines=sorted([x.strip() for x in captured.out.split("\n") if len(x.strip())>0])
+    assert len(ops["create_collection"]) == 0
+    assert len(ops["create_dir"]) == 0
+    assert len(ops["download"]) == 0
+    assert len(ops["upload"]) == 7
 
-    assert lines == ['/tempZone/home/rods/empty/more_data',
-        'Will create collection(s):',
-        "Will upload from '/tmp/testdata' to '/tempZone/home/rods/empty':",
-        'beach.rtf  727',
-        'bunny.rtf  10150',
-        'example.r  182',
-        'more_data/polarbear.txt  2717',
-        'plant.rtf  992',
-        'plant.rtf.copy  992',
-        'sun.rtf  661']
+    # captured = capsys.readouterr()
+    # lines=sorted([x.strip() for x in captured.out.split("\n") if len(x.strip())>0])
+
+    # assert lines == ['/tempZone/home/rods/empty/more_data',
+    #     'Will create collection(s):',
+    #     "Will upload from '/tmp/testdata' to '/tempZone/home/rods/empty':",
+    #     'beach.rtf  727',
+    #     'bunny.rtf  10150',
+    #     'example.r  182',
+    #     'more_data/polarbear.txt  2717',
+    #     'plant.rtf  992',
+    #     'plant.rtf.copy  992',
+    #     'sun.rtf  661']
 
     assert len(coll.data_objects)+len(coll.subcollections)==0, "Dry run did sync"
 

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -319,22 +319,22 @@ def ibridges_sync():
                   dry_run=args.dry_run,
         )
         if args.dry_run:
-            if len(ops["create_collection"]):
+            if len(ops["create_collection"]) > 0:
                 print("Create collections:\n")
                 for coll in ops["create_collection"]:
                     print(str(coll))
                 print("\n\n\n")
-            if len(ops["create_dir"]):
+            if len(ops["create_dir"]) > 0:
                 print("Create directories:\n")
                 for cur_dir in ops["create_dir"]:
                     print(str(cur_dir))
                 print("\n\n\n")
-            if len(ops["upload"]):
+            if len(ops["upload"]) > 0:
                 print("Upload files:\n")
                 for lpath, ipath in ops["upload"]:
                     print(f"{lpath} -> {ipath}")
                 print("\n\n\n")
-            if len(ops["download"]):
+            if len(ops["download"]) > 0:
                 print("Download files:\n")
                 for ipath, lpath in ops["download"]:
                     print(f"{ipath} -> {lpath}")

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -35,7 +35,7 @@ Available subcommands:
         Only updated files will be downloaded/uploaded.
     list:
         List the content of a collections, if no path is given, the home collection will be listed.
-    midir:
+    mkcoll:
         Create the collection and all its parent collections.
 
 The iBridges CLI does not implement the complete iBridges API. For example, there
@@ -313,8 +313,28 @@ def ibridges_sync():
 
 
     with interactive_auth(irods_env_path=_get_ienv_path()) as session:
-        sync_data(session,
+        ops = sync_data(session,
                   _parse_str(args.source, session),
                   _parse_str(args.destination, session),
                   dry_run=args.dry_run,
         )
+        if args.dry_run:
+            if len(ops["create_collection"]):
+                print("Create collections:\n")
+                for coll in ops["create_collection"]:
+                    print(str(coll))
+                print("\n\n\n")
+            if len(ops["create_dir"]):
+                print("Create directories:\n")
+                for cur_dir in ops["create_dir"]:
+                    print(str(cur_dir))
+                print("\n\n\n")
+            if len(ops["upload"]):
+                print("Upload files:\n")
+                for lpath, ipath in ops["upload"]:
+                    print(f"{lpath} -> {ipath}")
+                print("\n\n\n")
+            if len(ops["download"]):
+                print("Download files:\n")
+                for ipath, lpath in ops["download"]:
+                    print(f"{ipath} -> {lpath}")

--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -376,13 +376,14 @@ def perform_operations(session: Session, operations: dict, ignore_err: bool=Fals
         Ignore any errors and convert them into warnings if True.
 
     """
-    up_sizes = [ipath.size for ipath, _ in operations["download"]]
-    down_sizes = [lpath.stat().st_size for lpath, _ in operations["upload"]]
+    up_sizes = [lpath.stat().st_size for lpath, _ in operations["upload"]]
+    down_sizes = [ipath.size for ipath, _ in operations["download"]]
     # pbar = tqdm(total=sum(up_sizes) + sum(down_sizes), unit="MiB",
                 # bar_format="{desc}: {percentage:3.0f}% {n_fmt:.3f}/{total_fmt:.3f} "
                 # "[{elapsed}<{remaining}, {rate_fmt}{postfix}]")
     pbar = tqdm(total=sum(up_sizes) + sum(down_sizes), unit="B", unit_scale=True, unit_divisor=1024)
 
+    # print(operations["upload"])
     for col in operations["create_collection"]:
         IrodsPath.create_collection(session, col)
     for curdir in operations["create_dir"]:
@@ -390,6 +391,6 @@ def perform_operations(session: Session, operations: dict, ignore_err: bool=Fals
     for (lpath, ipath), size in zip(operations["upload"], up_sizes):
         upload(session, lpath, ipath, overwrite=True, ignore_err=ignore_err)
         pbar.update(size)
-    for (ipath, lpath), size in zip(operations["download"], up_sizes):
+    for (ipath, lpath), size in zip(operations["download"], down_sizes):
         download(session, ipath, lpath, overwrite=True, ignore_err=ignore_err)
         pbar.update(size)

--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -363,7 +363,7 @@ def create_collection(session: Session,
               ) from exc
 
 
-def perform_operations(session: Session, operations: dict):
+def perform_operations(session: Session, operations: dict, ignore_err: bool=False):
     """Perform data operations.
 
     Parameters
@@ -372,7 +372,8 @@ def perform_operations(session: Session, operations: dict):
         Session to do the data operations for.
     operations
         Dictionary containing the operations to perform.
-
+    ignore_err
+        Ignore any errors and convert them into warnings if True.
     """
     up_sizes = [ipath.size for ipath, _ in operations["download"]]
     down_sizes = [lpath.stat().st_size for lpath, _ in operations["upload"]]
@@ -386,9 +387,9 @@ def perform_operations(session: Session, operations: dict):
     for curdir in operations["create_dir"]:
         Path(curdir).mkdir(parents=True, exist_ok=True)
     for (lpath, ipath), size in zip(operations["upload"], up_sizes):
-        _obj_put(session, lpath, ipath, overwrite=True)
+        upload(session, lpath, ipath, overwrite=True, ignore_err=ignore_err)
         pbar.update(size)
     for (ipath, lpath), size in zip(operations["download"], up_sizes):
-        _obj_get(session, ipath, lpath, overwrite=True)
+        download(session, ipath, lpath, overwrite=True, ignore_err=ignore_err)
         pbar.update(size)
 

--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -364,6 +364,16 @@ def create_collection(session: Session,
 
 
 def perform_operations(session: Session, operations: dict):
+    """Perform data operations.
+
+    Parameters
+    ----------
+    session
+        Session to do the data operations for.
+    operations
+        Dictionary containing the operations to perform.
+
+    """
     up_sizes = [ipath.size for ipath, _ in operations["download"]]
     down_sizes = [lpath.stat().st_size for lpath, _ in operations["upload"]]
     # pbar = tqdm(total=sum(up_sizes) + sum(down_sizes), unit="MiB",

--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -378,12 +378,8 @@ def perform_operations(session: Session, operations: dict, ignore_err: bool=Fals
     """
     up_sizes = [lpath.stat().st_size for lpath, _ in operations["upload"]]
     down_sizes = [ipath.size for ipath, _ in operations["download"]]
-    # pbar = tqdm(total=sum(up_sizes) + sum(down_sizes), unit="MiB",
-                # bar_format="{desc}: {percentage:3.0f}% {n_fmt:.3f}/{total_fmt:.3f} "
-                # "[{elapsed}<{remaining}, {rate_fmt}{postfix}]")
     pbar = tqdm(total=sum(up_sizes) + sum(down_sizes), unit="B", unit_scale=True, unit_divisor=1024)
 
-    # print(operations["upload"])
     for col in operations["create_collection"]:
         IrodsPath.create_collection(session, col)
     for curdir in operations["create_dir"]:

--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -374,6 +374,7 @@ def perform_operations(session: Session, operations: dict, ignore_err: bool=Fals
         Dictionary containing the operations to perform.
     ignore_err
         Ignore any errors and convert them into warnings if True.
+
     """
     up_sizes = [ipath.size for ipath, _ in operations["download"]]
     down_sizes = [lpath.stat().st_size for lpath, _ in operations["upload"]]

--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -392,4 +392,3 @@ def perform_operations(session: Session, operations: dict, ignore_err: bool=Fals
     for (ipath, lpath), size in zip(operations["download"], up_sizes):
         download(session, ipath, lpath, overwrite=True, ignore_err=ignore_err)
         pbar.update(size)
-

--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -65,7 +65,7 @@ def _obj_put(session: Session, local_path: Union[str, Path], irods_path: Union[s
         except (PermissionError, OSError) as error:
             raise PermissionError(f'Cannot read {error.filename}.') from error
         except irods.exception.CAT_NO_ACCESS_PERMISSION as error:
-            raise PermissionError(f'Cannot write {str(irods_path)}.')
+            raise PermissionError(f'Cannot write {str(irods_path)}.') from error
     else:
         raise irods.exception.OVERWRITE_WITHOUT_FORCE_FLAG
 

--- a/ibridges/path.py
+++ b/ibridges/path.py
@@ -426,4 +426,5 @@ def _get_subcoll_paths(session,
     coll_query = session.irods_session.query(icat.COLL_NAME)
     coll_query = coll_query.filter(icat.LIKE(icat.COLL_NAME, coll.path+"/%"))
 
-    return [CachedIrodsPath(session, None, False, None, p) for r in coll_query.get_results() for p in r.values()]
+    return [CachedIrodsPath(session, None, False, None, p) for r in coll_query.get_results()
+            for p in r.values()]

--- a/ibridges/path.py
+++ b/ibridges/path.py
@@ -281,7 +281,7 @@ class IrodsPath():
         return PurePosixPath(self.absolute_path()).relative_to(PurePosixPath(other.absolute_path()))
 
     @property
-    def size(self):
+    def size(self) -> int:
         """Collect the sizes of a data object or a collection.
 
         Returns
@@ -322,7 +322,9 @@ class IrodsPath():
         raise ValueError("Cannot take checksum of irods path neither a dataobject or collection.")
 
 
-def _recursive_walk(cur_col, sub_collections, all_dataobjects, start_col, depth, max_depth):
+def _recursive_walk(cur_col: IrodsPath, sub_collections: dict[str, list[IrodsPath]],
+                    all_dataobjects: dict[str, list[IrodsPath]], start_col: IrodsPath,
+                    depth: int, max_depth: Optional[int]):
     if cur_col != start_col:
         yield cur_col
     if max_depth is not None and depth >= max_depth:
@@ -364,24 +366,24 @@ class CachedIrodsPath(IrodsPath):
         super().__init__(session, *args)
 
     @property
-    def size(self):
+    def size(self) -> int:
         """See IrodsPath."""
         if self._size is None:
             return super().size
         return self._size
 
     @property
-    def checksum(self):
+    def checksum(self) -> str:
         """See IrodsPath."""
         if self._checksum is None:
             return super().checksum
         return self._checksum
 
-    def dataobject_exists(self):
+    def dataobject_exists(self) -> bool:
         """See IrodsPath."""
         return self._is_dataobj
 
-    def collection_exists(self):
+    def collection_exists(self) -> bool:
         """See IrodsPath."""
         return not self._is_dataobj
 
@@ -419,7 +421,7 @@ def _get_data_objects(session,
 
 
 def _get_subcoll_paths(session,
-                     coll: irods.collection.iRODSCollection) -> list:
+                       coll: irods.collection.iRODSCollection) -> list:
     """Retrieve all sub collections in a sub tree starting at coll and returns their IrodsPaths."""
     coll_query = session.irods_session.query(icat.COLL_NAME)
     coll_query = coll_query.filter(icat.LIKE(icat.COLL_NAME, coll.path+"/%"))

--- a/ibridges/path.py
+++ b/ibridges/path.py
@@ -310,7 +310,7 @@ class IrodsPath():
         """
         if self.dataobject_exists():
             dataobj = self.dataobject
-            return dataobj.chksum if dataobj.chksum is not None else dataobj.checksum()
+            return dataobj.checksum if dataobj.checksum is not None else dataobj.chksum()
         if self.collection_exists():
             raise ValueError("Cannot take checksum of a collection.")
         raise ValueError("Cannot take checksum of irods path neither a dataobject or collection.")

--- a/ibridges/sync.py
+++ b/ibridges/sync.py
@@ -62,8 +62,11 @@ def sync_data(session: Session,
 
     Returns
     -------
-        A dict object containing two keys: 'changed_folders' and 'changed_files'.
-        These contain lists of changed folders and files, respectively
+        A dict object containing four keys:
+            'create_dir' : Create local directories when sync from iRODS to local
+            'create_collection' : Create tcollections when sync from local to iRODS
+            'upload' : Tuple(local path, iRODS path) when sync from local to iRODS
+            'download' : Tuple(iRODS path, local path) when sync from iRODS to local
         (or of to-be-changed folders and files, when in dry-run mode).
 
     """

--- a/ibridges/sync.py
+++ b/ibridges/sync.py
@@ -12,15 +12,11 @@ import base64
 import os
 from hashlib import sha256
 from pathlib import Path
-from typing import NamedTuple, Optional, Union
-
-from irods.collection import iRODSCollection
-from tqdm import tqdm
+from typing import Optional, Union
 
 from ibridges.data_operations import perform_operations
 from ibridges.path import IrodsPath
 from ibridges.session import Session
-from ibridges.util import get_collection, get_dataobject
 
 
 def sync_data(session: Session,

--- a/ibridges/sync.py
+++ b/ibridges/sync.py
@@ -84,10 +84,11 @@ def sync_data(session: Session,
                                     depth=max_level)
     else:
         ops = _up_sync_operations(Path(source), target, copy_empty_folders=copy_empty_folders,
-                                    depth=max_level)
+                                  depth=max_level)
 
     if not dry_run:
         perform_operations(session, ops, ignore_err=ignore_err)
+
     return ops
 
 def _param_checks(source, target):

--- a/ibridges/sync.py
+++ b/ibridges/sync.py
@@ -17,71 +17,11 @@ from typing import NamedTuple, Optional, Union
 from irods.collection import iRODSCollection
 from tqdm import tqdm
 
-from ibridges.data_operations import (
-    create_collection,
-    download,
-    upload,
-)
+from ibridges.data_operations import perform_operations
 from ibridges.path import IrodsPath
 from ibridges.session import Session
 from ibridges.util import get_collection, get_dataobject
 
-
-class FileObject(NamedTuple):
-    """Object to hold attributes from local and remote files."""
-
-    name: str
-    path: str
-    size: int
-    checksum: str
-
-class FolderObject:
-    """Object to hold attributes from local and remote folders/collections."""
-
-    def __init__(self,
-                 path: str = '',
-                 n_files: int = 0,
-                 n_folders: int = 0) -> None:
-        """Initialize FolderObject.
-
-        Attributes
-        ----------
-        path : str
-            Path, relative to source or target root
-        n_files : int
-            Number of files in folder
-        n_folders : int
-            Number of subfolders in folder
-
-        Methods
-        -------
-        is_empty()
-            Check whether folder is empty.
-
-        """
-        self.path=path
-        self.n_files=n_files
-        self.n_folders=n_folders
-
-    def is_empty(self):
-        """Check to see if folder has anything (files or subfolders) in it."""
-        return (self.n_files+self.n_folders)==0
-
-    def __repr__(self):
-        """Give a nicer representation for debug purposes."""
-        return f"{self.__class__.__name__}(path='{self.path}', n_files={self.n_files}, \
-            n_folders={self.n_folders})"
-
-    def __eq__(self, other: object):
-        """Check whether two folders (paths) are the same."""
-        if not isinstance(other, FolderObject):
-            return NotImplemented
-
-        return self.path==other.path
-
-    def __hash__(self):
-        """Hash the path as a hash for the folder."""
-        return hash(self.path)
 
 def sync_data(session: Session,
          source: Union[str, Path, IrodsPath],
@@ -136,65 +76,20 @@ def sync_data(session: Session,
     if isinstance(source, IrodsPath):
         if not source.collection_exists():
             raise ValueError(f"Source collection '{source.absolute_path()}' does not exist")
-        src_files, src_folders=_get_irods_tree(
-            coll=get_collection(session=session, path=source),
-            max_level=max_level)
     else:
         if not Path(source).is_dir():
             raise ValueError(f"Source folder '{source}' does not exist")
-        src_files, src_folders=_get_local_tree(
-            path=Path(source),
-            max_level=max_level)
 
-    if isinstance(target, IrodsPath):
-        if not target.collection_exists():
-            raise ValueError(f"Target collection '{target.absolute_path()}' does not exist")
-        tgt_files, tgt_folders=_get_irods_tree(
-            coll=get_collection(session=session, path=target),
-            max_level=max_level)
+    if isinstance(source, IrodsPath):
+        ops = _down_sync_operations(session, source, target, copy_empty_folders=copy_empty_folders,
+                                    depth=max_level)
     else:
-        if not Path(target).is_dir():
-            raise ValueError(f"Target folder '{target}' does not exist")
-        tgt_files, tgt_folders=_get_local_tree(
-            path=Path(target),
-            max_level=max_level)
+        ops = _up_sync_operations(session, source, target, copy_empty_folders=copy_empty_folders,
+                                    depth=max_level)
 
-    folders_diff=sorted(
-        set(src_folders).difference(set(tgt_folders)),
-        key=lambda x: (x.path.count('/'), x.path))
-
-    files_diff=sorted(
-        set(src_files).difference(set(tgt_files)),
-        key=lambda x: (x.path.count('/'), x.path))
-
-    if isinstance(target, IrodsPath):
-        _create_irods_collections(
-            session=session,
-            target=target,
-            collections=folders_diff,
-            dry_run=dry_run,
-            copy_empty_folders=copy_empty_folders)
-        _copy_local_to_irods(
-            session=session,
-            source=Path(source),
-            target=target,
-            files=files_diff,
-            dry_run=dry_run,
-            ignore_err=ignore_err)
-    else:
-        _create_local_folders(
-            target=Path(target),
-            folders=folders_diff,
-            dry_run=dry_run,
-            copy_empty_folders=copy_empty_folders)
-        _copy_irods_to_local(
-            session=session,
-            source=source,  # type: ignore
-            target=Path(target),
-            objects=files_diff,
-            dry_run=dry_run,
-            ignore_err=ignore_err)
-    return {'changed_folders': folders_diff, 'changed_files': files_diff}
+    if not dry_run:
+        perform_operations(session, ops)
+    return ops
 
 def _param_checks(source, target):
     if not isinstance(source, IrodsPath) and not isinstance(target, IrodsPath):
@@ -204,6 +99,9 @@ def _param_checks(source, target):
         raise TypeError("iRODS to iRODS copying is not supported.")
 
 def _calc_checksum(filepath):
+    if isinstance(filepath, IrodsPath):
+        dataobj = filepath.dataobject
+        return dataobj.checksum if dataobj.checksum else dataobj.chksum()
     f_hash=sha256()
     memv=memoryview(bytearray(128*1024))
     with open(filepath, 'rb', buffering=0) as file:
@@ -211,156 +109,51 @@ def _calc_checksum(filepath):
             f_hash.update(memv[:item])
     return f"sha2:{str(base64.b64encode(f_hash.digest()), encoding='utf-8')}"
 
-def _get_local_tree(path: Path,
-                    max_level: Optional[int] = None):
+def _down_sync_operations(session, isource_path, ldest_path, copy_empty_folders=True, depth=None):
+    operations = {
+        "create_dir": set(),
+        "create_collection": set(),
+        "upload": [],
+        "download": [],
+    }
+    for ipath in isource_path.walk(depth=depth):
+        lpath = ldest_path.joinpath(*ipath.relative_to(isource_path)._parts)
+        if ipath.dataobject_exists():
+            if lpath.is_file():
+                l_chksum = _calc_checksum(lpath)
+                i_chksum = _calc_checksum(ipath)
+                if i_chksum != l_chksum:
+                    operations["download"].append((ipath, lpath))
+            else:
+                operations["download"].append((ipath, lpath))
+            if not lpath.parent.exists():
+                operations["create_dir"].add(str(lpath.parent))
+        elif ipath.collection_exists() and copy_empty_folders:
+            if not lpath.exists():
+                operations["create_dir"].add(str(lpath))
+    return operations
 
-    # change all sep into /, regardless of platform, for easier comparison
-    def fix_local_path(path: str):
-        return "/".join(path.split(os.sep))
-
-    objects=[]
-    collections=[]
-
-    for root, dirs, files in os.walk(path):
-        for file in files:
-            full_path=Path(root) / file
-            rel_path=str(full_path)[len(str(path)):].lstrip(os.sep)
-            if max_level is None or rel_path.count(os.sep)<max_level:
-                objects.append(FileObject(
-                    name=file,
-                    path=fix_local_path(rel_path),
-                    size=full_path.stat().st_size,
-                    checksum=_calc_checksum(full_path)))
-
-        collections.extend([FolderObject(
-                fix_local_path(str(Path(root) / dir)[len(str(path)):].lstrip(os.sep)),
-                len([x for x in Path(f"{root}{os.sep}{dir}").iterdir() if x.is_file()]),
-                len([x for x in Path(f"{root}{os.sep}{dir}").iterdir() if x.is_dir()])
-            )
-            for dir in dirs if max_level is None or dir.count(os.sep)<max_level-1])
-
-    return objects, collections
-
-def _get_irods_tree(coll: iRODSCollection,
-                    root: str = '',
-                    level: int = 0,
-                    max_level: Optional[int] = None):
-
-    root=coll.path if len(root)==0 else root
-
-    # chksum() (re)calculates checksum, call only when checksum is empty
-    objects=[FileObject(
-        x.name,
-        x.path[len(root):].lstrip('/'),
-        x.size,
-        x.checksum if x.checksum is not None and len(x.checksum)>0 else x.chksum())
-        for x in coll.data_objects]
-
-    if max_level is None or level<max_level-1:
-        collections=[FolderObject(
-            x.path[len(root):].lstrip('/'),
-            len(x.data_objects),
-            len(x.subcollections)) for x in coll.subcollections]
-
-        for subcoll in coll.subcollections:
-            subobjects, subcollections=_get_irods_tree(
-                coll=subcoll,
-                root=root,
-                level=level+1,
-                max_level=max_level)
-            objects.extend(subobjects)
-            collections.extend(subcollections)
-    else:
-        collections=[]
-
-    return objects, collections
-
-def _create_irods_collections(session: Session,
-                              target: IrodsPath,
-                              collections: list[FolderObject],
-                              dry_run: bool,
-                              copy_empty_folders: bool):
-    new_colls=[str(target / x.path) for x in collections if not x.is_empty() or copy_empty_folders]
-    if dry_run:
-        print("Will create collection(s):")
-        print(*[f"  {x}" for x in new_colls], sep='\n')
-        return
-    for coll in new_colls:
-        create_collection(session, coll)
-
-def _create_local_folders(target: Path,
-                          folders: list[FolderObject],
-                          dry_run: bool,
-                          copy_empty_folders: bool):
-    new_folders=[target / Path(x.path) for x in folders if not x.is_empty() or copy_empty_folders]
-    if dry_run:
-        print("Will create folder(s):")
-        print(*[f"  {x}" for x in new_folders], sep='\n')
-        return
-    for folder in new_folders:
-        folder.mkdir(parents=True, exist_ok=True)
-
-def _copy_local_to_irods(session: Session,
-                         source: Path,
-                         target: IrodsPath,
-                         files: list[FileObject],
-                         dry_run: bool,
-                         ignore_err: bool) -> None:
-    if dry_run:
-        print(f"Will upload from '{source}' to '{target}':")
-        print(*[f"  {x.path}  {x.size}" for x in files], sep='\n')
-        return
-
-    if len(files)==0:
-        return
-
-    pbar=tqdm(desc='Uploading', total=sum(x.size for x in files))
-    for file in files:
-        source_path=Path(source) / file.path
-        target_path=str(target / file.path)
-        try:
-            upload(session=session,
-                    local_path=source_path,
-                    irods_path=target_path,
-                    overwrite=True,
-                    ignore_err=ignore_err)
-            obj=get_dataobject(session, target_path)
-            if file.checksum != \
-                    (obj.checksum if obj.checksum is not None and len(obj.checksum)>0
-                     else obj.chksum()):
-                raise ValueError(f"Checksum mismatch after upload: '{target_path}'")
-
-            pbar.update(file.size)
-        except Exception as err:
-            raise ValueError(f"Uploading '{source_path}' failed: {repr(err)}") from err
-
-def _copy_irods_to_local(session: Session,
-                         source: IrodsPath,
-                         target: Path,
-                         objects: list[FileObject],
-                         dry_run: bool,
-                         ignore_err: bool) -> None:
-    if dry_run:
-        print(f"Will download from '{source}' to '{target}':")
-        print(*[f"  {x.path}  {x.size}" for x in objects], sep='\n')
-        return
-
-    if len(objects)==0:
-        return
-
-    pbar=tqdm(desc='Downloading', total=sum(x.size for x in objects))
-    for obj in objects:
-        target_path=Path(target) / obj.path
-        source_path=str(source / obj.path)
-        try:
-            download(session=session,
-                        irods_path=source_path,
-                        local_path=target_path,
-                        overwrite=True,
-                        ignore_err=ignore_err)
-            if obj.checksum != _calc_checksum(target_path):
-                raise ValueError(f"Checksum mismatch after download: '{source_path}'")
-
-            pbar.update(obj.size)
-        except Exception as err:
-            raise ValueError(f"Downloading '{source_path}' failed: {repr(err)}") from err
+def _up_sync_operations(session, lsource_path, idest_path, copy_empty_folders=True, depth=None):
+    operations = {
+        "create_dir": set(),
+        "create_collection": set(),
+        "upload": [],
+        "download": [],
+    }
+    for root, folders, files in os.walk(lsource_path):
+        root_part = Path(root).relative_to(lsource_path)
+        root_ipath = idest_path.joinpath(*root_part.parts)
+        for cur_file in files:
+            ipath = root_ipath / cur_file
+            lpath = lsource_path / root_part / cur_file
+            if ipath.dataobject_exists():
+                l_chksum = _calc_checksum(lpath)
+                i_chksum = _calc_checksum(ipath)
+                if i_chksum != l_chksum:
+                    operations["upload"].append((lpath, ipath))
+            else:
+                operations["upload"].append((lpath, ipath))
+        for fold in folders:
+            operations["create_collection"].add(str(root_ipath / fold))
+        operations["create_collection"].add(str(root_ipath))
+    return operations

--- a/ibridges/sync.py
+++ b/ibridges/sync.py
@@ -100,8 +100,7 @@ def _param_checks(source, target):
 
 def _calc_checksum(filepath):
     if isinstance(filepath, IrodsPath):
-        dataobj = filepath.dataobject
-        return dataobj.checksum if dataobj.checksum else dataobj.chksum()
+        return filepath.checksum
     f_hash=sha256()
     memv=memoryview(bytearray(128*1024))
     with open(filepath, 'rb', buffering=0) as file:

--- a/ibridges/sync.py
+++ b/ibridges/sync.py
@@ -17,6 +17,7 @@ from typing import Optional, Union
 from ibridges.data_operations import perform_operations
 from ibridges.path import IrodsPath
 from ibridges.session import Session
+from ibridges.util import is_collection
 
 
 def sync_data(session: Session,
@@ -154,4 +155,7 @@ def _up_sync_operations(lsource_path, idest_path, copy_empty_folders=True, depth
             for fold in folders:
                 operations["create_collection"].add(str(root_ipath / fold))
         operations["create_collection"].add(str(root_ipath))
+
+    operations["create_collection"] = set(col_str for col_str in operations["create_collection"]
+                                          if not IrodsPath(idest_path.session, col_str).collection_exists())
     return operations

--- a/ibridges/sync.py
+++ b/ibridges/sync.py
@@ -112,7 +112,7 @@ def _down_sync_operations(isource_path, ldest_path, copy_empty_folders=True, dep
         "download": [],
     }
     for ipath in isource_path.walk(depth=depth):
-        lpath = ldest_path.joinpath(*ipath.relative_to(isource_path)._parts)
+        lpath = ldest_path.joinpath(*ipath.relative_to(isource_path).parts)
         if ipath.dataobject_exists():
             if lpath.is_file():
                 l_chksum = _calc_checksum(lpath)

--- a/ibridges/sync.py
+++ b/ibridges/sync.py
@@ -160,6 +160,6 @@ def _up_sync_operations(lsource_path, idest_path, copy_empty_folders=True, depth
             for fold in folders:
                 if str(root_ipath / fold) not in remote_ipaths:
                     operations["create_collection"].add(str(root_ipath / fold))
-        if str(root_ipath) not in remote_ipaths:
+        if str(root_ipath) not in remote_ipaths and str(root_ipath) != str(idest_path):
             operations["create_collection"].add(str(root_ipath))
     return operations

--- a/ibridges/sync.py
+++ b/ibridges/sync.py
@@ -157,5 +157,6 @@ def _up_sync_operations(lsource_path, idest_path, copy_empty_folders=True, depth
         operations["create_collection"].add(str(root_ipath))
 
     operations["create_collection"] = set(col_str for col_str in operations["create_collection"]
-                                          if not IrodsPath(idest_path.session, col_str).collection_exists())
+                                          if not IrodsPath(idest_path.session, col_str
+                                                           ).collection_exists())
     return operations


### PR DESCRIPTION
A new version of the synchronization method that fixes #157, because it does only checksum the files that might be overwritten. Some rudimentary performance checks indicate it is also faster for the download version, could just be random though.

This also fixes an issue related to the `IrodsPath.walk` method that made subcollections appear twice and made the procedure very slow.