### PR TITLE
Add tree for the iBridges CLI

### DIFF
--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -1,4 +1,6 @@
 """Command line tools for the iBridges library."""
+from __future__ import annotations
+
 import argparse
 import json
 import sys
@@ -367,7 +369,7 @@ _tree_elements = {
 }
 
 
-def _print_build_list(build_list, prefix, pels, show_max=10):
+def _print_build_list(build_list: list[str], prefix: str, pels: dict[str, str], show_max: int = 10):
     if len(build_list) > show_max:
         n_half = (show_max-1)//2
         for item in build_list[:n_half]:
@@ -381,7 +383,8 @@ def _print_build_list(build_list, prefix, pels, show_max=10):
     if len(build_list) > 0:
         print(prefix + pels["last"] + build_list[-1])
 
-def _tree(ipath: IrodsPath, path_list, pels, prefix='', show_max=10):
+def _tree(ipath: IrodsPath, path_list: list[IrodsPath], pels: dict[str, str], prefix: str = '',
+          show_max: int = 10):
     """Generate A recursive generator, given a directory Path object.
 
     will yield a visual tree structure line by line

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -367,7 +367,7 @@ _tree_elements = {
 }
 
 
-def _print_build_list(build_list, prefix, show_max=10, pels=_tree_elements["pretty"]):
+def _print_build_list(build_list, prefix, pels, show_max=10):
     if len(build_list) > show_max:
         n_half = (show_max-1)//2
         for item in build_list[:n_half]:
@@ -381,7 +381,7 @@ def _print_build_list(build_list, prefix, show_max=10, pels=_tree_elements["pret
     if len(build_list) > 0:
         print(prefix + pels["last"] + build_list[-1])
 
-def _tree(ipath: IrodsPath, path_list, prefix='', show_max=10, pels=_tree_elements["pretty"]):
+def _tree(ipath: IrodsPath, path_list, pels, prefix='', show_max=10):
     """Generate A recursive generator, given a directory Path object.
 
     will yield a visual tree structure line by line
@@ -452,4 +452,3 @@ def ibridges_tree():
         if args.depth is not None:
             print_str += " (possibly more at higher depths)"
         print(print_str)
-


### PR DESCRIPTION
This PR adds a new feature to the CLI that makes it possible to print the collection/subcollection tree.

Currently there is an issue with the tree being slow + subcollections showing up twice. This should be fixed after #158 is merged. I suggest we merge that PR first before merging this one.