### PR TITLE
Don't use assert for control flow

### DIFF
--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -131,7 +131,8 @@ def ibridges_init():
     ienv_path = _set_ienv_path(args.irods_env_path)
     print(ienv_path, args.irods_env_path)
     with interactive_auth(irods_env_path=ienv_path) as session:
-        raise ValueError(f"Irods session '{session}' is not a session.")
+        if not isinstance(session, Session):
+            raise ValueError(f"Irods session '{session}' is not a session.")
     print("ibridges init was succesful.")
 
 

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -131,7 +131,7 @@ def ibridges_init():
     ienv_path = _set_ienv_path(args.irods_env_path)
     print(ienv_path, args.irods_env_path)
     with interactive_auth(irods_env_path=ienv_path) as session:
-        assert isinstance(session, Session)
+        raise ValueError(f"Irods session '{session}' is not a session.")
     print("ibridges init was succesful.")
 
 

--- a/ibridges/path.py
+++ b/ibridges/path.py
@@ -28,9 +28,15 @@ class IrodsPath():
         args:
             Specification of the path. For example: "x/z" or "x", "z".
 
+        Raises
+        ------
+        ValueError:
+            If the provided session does not have an 'irods_session' attribute.
+
         """
         self.session = session
-        assert hasattr(session, "irods_session")
+        if not hasattr(session, "irods_session"):
+            raise ValueError(f'str{self} does not have a valid session.')
         # We don't want recursive IrodsPaths, so we take the
         # path outside of the IrodsPath object.
         args = [a._path if isinstance(a, IrodsPath) else a

--- a/ibridges/path.py
+++ b/ibridges/path.py
@@ -36,7 +36,7 @@ class IrodsPath():
         """
         self.session = session
         if not hasattr(session, "irods_session"):
-            raise ValueError(f'str{self} does not have a valid session.')
+            raise ValueError(f'{str(self)} does not have a valid session.')
         # We don't want recursive IrodsPaths, so we take the
         # path outside of the IrodsPath object.
         args = [a._path if isinstance(a, IrodsPath) else a


### PR DESCRIPTION
The `assert` statement in `path.py` caused me some headaches when working on unit tests for https://github.com/UtrechtUniversity/ibridges-ansible. I was getting `AssertionError` and assumed this was being triggered by my mock objects, but it turns out I was just passing in the wrong object for session, I was thereby triggering an `AssertError` from within iBridges itself.

I think `AssertionError` should [probably not be thrown to control ordinary program flow](https://www.askpython.com/python/built-in-methods/assertions-in-python). I've replaced the `assert`s with `ValueError`s here, but maybe another error class makes even more sense.