### PR TITLE
Change default connection timeout to 25000

### DIFF
--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -15,7 +15,6 @@ import irods.collection
 import irods.data_object
 import irods.exception
 import irods.keywords as kw
-from irods import DEFAULT_CONNECTION_TIMEOUT
 from tqdm import tqdm
 
 from ibridges.path import CachedIrodsPath, IrodsPath

--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -378,14 +378,18 @@ def perform_operations(session: Session, operations: dict, ignore_err: bool=Fals
     pbar = tqdm(total=sum(up_sizes) + sum(down_sizes), unit="B", unit_scale=True, unit_divisor=1024,
                 disable=disable)
 
+    # The code below does not work as expected, since connections in the
+    # pool can be reused. Another solution for dynamic timeouts might be needed
+    # Leaving the previous solution in here for documentation.
+
     # For large files, the checksum computation might take too long, which can result in a timeout.
     # This is why we increase the time out from file sizes > 1 GB
     # This might still result in a time out if your server is very busy or a potato.
-    max_size = max([*up_sizes, *down_sizes, 0])
-    original_timeout = session.irods_session.pool.connection_timeout
-    if max_size > 1e9 and original_timeout == DEFAULT_CONNECTION_TIMEOUT:
-        session.irods_session.pool.connection_timeout = int(
-            DEFAULT_CONNECTION_TIMEOUT*(max_size/1e9)+0.5)
+    # max_size = max([*up_sizes, *down_sizes, 0])
+    # original_timeout = session.irods_session.pool.connection_timeout
+    # if max_size > 1e9 and original_timeout == DEFAULT_CONNECTION_TIMEOUT:
+    #     session.irods_session.pool.connection_timeout = int(
+    #         DEFAULT_CONNECTION_TIMEOUT*(max_size/1e9)+0.5)
 
     for col in operations["create_collection"]:
         IrodsPath.create_collection(session, col)
@@ -406,7 +410,7 @@ def perform_operations(session: Session, operations: dict, ignore_err: bool=Fals
         _obj_get(session, ipath, lpath, overwrite=True, ignore_err=ignore_err, options=options,
                  resc_name=resc_name)
         pbar.update(size)
-    session.irods_session.pool.connection_timeout = original_timeout
+    # session.irods_session.pool.connection_timeout = original_timeout
 
 
 def sync(session: Session,

--- a/ibridges/session.py
+++ b/ibridges/session.py
@@ -72,6 +72,9 @@ class Session:
             raise TypeError(f"Error reading environment file '{irods_env_path}': "
                             f"expected dictionary, got {type(irods_env)}.")
 
+        if "connection_timeout" not in irods_env:
+            irods_env["connection_timeout"] = 25000
+
         self._password = password
         self._irods_env: dict = irods_env
         self._irods_env_path = irods_env_path


### PR DESCRIPTION
The current dynamic setting of the connection_timeout in the pool does not work as expected. We're returning for now to using a static connection timeout. Since users will be more likely run into a timeout that is too short, we'll increase the default timeout to a large number for now. This can still be set to a lower amount in the irods_environment.json file if needed.

Fixes #197 
