### PR TITLE
Implement aliases for the CLI

### DIFF
--- a/docker/irods_client/tests/test_sync.py
+++ b/docker/irods_client/tests/test_sync.py
@@ -1,5 +1,6 @@
-from ibridges.data_operations import _calc_checksum, create_collection, sync
+from ibridges.data_operations import create_collection, sync
 from ibridges.path import IrodsPath
+from ibridges.util import calc_checksum
 
 
 def test_sync_dry_run(session, testdata, capsys):
@@ -42,7 +43,7 @@ def test_sync_upload_download(session, testdata, tmpdir):
         if cur_file.is_file():
             assert s_ipath.dataobject_exists(), "File not uploaded"
             cur_obj=s_ipath.dataobject
-            assert _calc_checksum(cur_file)==(cur_obj.checksum
+            assert calc_checksum(cur_file)==(cur_obj.checksum
                 if len(cur_obj.checksum)>0
                 else cur_obj.chksum()), "Checksums not identical after upload"
 
@@ -51,7 +52,7 @@ def test_sync_upload_download(session, testdata, tmpdir):
     s_ipath = IrodsPath(session, "~/empty/more_data/polarbear.txt")
     assert s_ipath.dataobject_exists(), "File in subfolder not uploaded"
     obj = s_ipath.dataobject
-    assert _calc_checksum(testdata / "more_data" / "polarbear.txt")== \
+    assert calc_checksum(testdata / "more_data" / "polarbear.txt")== \
         (obj.checksum if len(obj.checksum)>0 else obj.chksum()), \
             "Checksums not identical after upload"
 
@@ -66,12 +67,12 @@ def test_sync_upload_download(session, testdata, tmpdir):
     for cur_file in list(testdata.glob("*")):
         if cur_file.is_file():
             assert (tmpdir / cur_file.name).exists(), "File not downloaded"
-            assert _calc_checksum(tmpdir / cur_file.name)== \
-                _calc_checksum(testdata / cur_file.name), "Checksums not identical after download"
+            assert calc_checksum(tmpdir / cur_file.name)== \
+                calc_checksum(testdata / cur_file.name), "Checksums not identical after download"
         elif cur_file.is_dir():
             assert (tmpdir / cur_file.name).exists(), "Subfolder not downloaded"
 
     assert (tmpdir / "more_data" / "polarbear.txt").exists(), "File in subfolder not downloaded"
-    assert _calc_checksum(tmpdir / "more_data" / "polarbear.txt")== \
-        _calc_checksum(testdata  / "more_data" / "polarbear.txt"), \
+    assert calc_checksum(tmpdir / "more_data" / "polarbear.txt")== \
+        calc_checksum(testdata  / "more_data" / "polarbear.txt"), \
             "Checksums not identical after download"

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -173,6 +173,9 @@ def _cli_auth(ienv_path: Union[None, str, Path]):
     if str(ienv_path) in ibridges_conf.get("aliases", {}):
         alias = str(ienv_path)
         ienv_path = ibridges_conf["aliases"][alias]["path"]
+    if not Path(ienv_path).exists():
+        print(f"Error: Irods environment file or alias '{ienv_path}' does not exist.")
+        sys.exit(124)
     session = interactive_auth(irods_env_path=ienv_path)
     if alias is not None:
         with open(DEFAULT_IRODSA_PATH, "r", encoding="utf-8") as handle:

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -6,7 +6,7 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Optional, Union
+from typing import Union
 
 from ibridges.data_operations import download, sync, upload
 from ibridges.interactive import DEFAULT_IENV_PATH, DEFAULT_IRODSA_PATH, interactive_auth
@@ -128,6 +128,7 @@ def _set_alias(alias, ienv_path: Union[str, Path]):
 
 def _set_ienv_path(ienv_path: Union[None, str, Path]):
     ibridges_conf = _get_ibridges_conf(ienv_path)
+    alias = None
 
     if ibridges_conf is None:
         return None

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -158,7 +158,7 @@ def _get_ienv_path() -> Union[None, str]:
         return None
 
 
-def _cli_auth(ienv_path: Optional[str, Path]):
+def _cli_auth(ienv_path: Union[None, str, Path]):
     ibridges_conf = _get_ibridges_conf(ienv_path)
     alias = None
     if str(ienv_path) in ibridges_conf.get("aliases", {}):
@@ -169,6 +169,7 @@ def _cli_auth(ienv_path: Optional[str, Path]):
         with open(DEFAULT_IRODSA_PATH, "r", encoding="utf-8") as handle:
             irodsa_content = handle.read()
         if irodsa_content != ibridges_conf["aliases"][alias]["irodsa_backup"]:
+            ienv_path = ienv_path if ienv_path is not None else DEFAULT_IENV_PATH
             _set_alias(alias, ienv_path)
     return session
 

--- a/ibridges/__main__.py
+++ b/ibridges/__main__.py
@@ -105,13 +105,13 @@ def main() -> None:
         print(f"Invalid subcommand ({subcommand}). For help see ibridges --help")
         sys.exit(1)
 
-def _get_ibridges_conf(ienv_path):
+def _get_ibridges_conf(ienv_path) -> dict:
     try:
         with open(IBRIDGES_CONFIG_FP, "r", encoding="utf-8") as handle:
             ibridges_conf = json.load(handle)
     except FileNotFoundError:
         if ienv_path is None:
-            return None
+            return {}
         ibridges_conf = {}
         IBRIDGES_CONFIG_FP.parent.mkdir(exist_ok=True)
     return ibridges_conf
@@ -130,11 +130,11 @@ def _set_alias(alias, ienv_path: Union[str, Path]):
     with open(IBRIDGES_CONFIG_FP, "w", encoding="utf-8") as handle:
         json.dump(ibridges_conf, handle)
 
-def _set_ienv_path(ienv_path: Union[None, str, Path], alias: Optional[str] = None):
-    ibridges_conf = _get_ibridges_conf(ienv_path)
-
-    if ibridges_conf is None:
+def _set_ienv_path(ienv_path: Union[None, str, Path], alias: Optional[str] = None) -> Optional[str]:
+    if ienv_path is None and alias is None:
         return None
+
+    ibridges_conf = _get_ibridges_conf(ienv_path)
 
     # Detect possible alias.
     if alias is None and str(ienv_path) in ibridges_conf.get("aliases", {}):
@@ -173,6 +173,7 @@ def _cli_auth(ienv_path: Union[None, str, Path]):
     if str(ienv_path) in ibridges_conf.get("aliases", {}):
         alias = str(ienv_path)
         ienv_path = ibridges_conf["aliases"][alias]["path"]
+    ienv_path = ienv_path if ienv_path is not None else DEFAULT_IENV_PATH
     if not Path(ienv_path).exists():
         print(f"Error: Irods environment file or alias '{ienv_path}' does not exist.")
         sys.exit(124)
@@ -181,7 +182,6 @@ def _cli_auth(ienv_path: Union[None, str, Path]):
         with open(DEFAULT_IRODSA_PATH, "r", encoding="utf-8") as handle:
             irodsa_content = handle.read()
         if irodsa_content != ibridges_conf["aliases"][alias]["irodsa_backup"]:
-            ienv_path = ienv_path if ienv_path is not None else DEFAULT_IENV_PATH
             _set_alias(alias, ienv_path)
     return session
 

--- a/ibridges/interactive.py
+++ b/ibridges/interactive.py
@@ -9,6 +9,7 @@ from typing import Optional, Union
 from ibridges.session import LoginError, PasswordError, Session
 
 DEFAULT_IENV_PATH = Path(os.path.expanduser("~")).joinpath(".irods", "irods_environment.json")
+DEFAULT_IRODSA_PATH = Path.home() / ".irods" / ".irodsA"
 
 
 def interactive_auth(
@@ -44,10 +45,7 @@ def interactive_auth(
         raise FileNotFoundError
 
     session = None
-    if (
-        os.path.exists(Path(os.path.expanduser("~")).joinpath(".irods", ".irodsA"))
-        and password is None
-    ):
+    if DEFAULT_IRODSA_PATH.is_file() and password is None:
         session = _from_pw_file(irods_env_path)
 
     if password is not None:

--- a/ibridges/util.py
+++ b/ibridges/util.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import base64
 from collections.abc import Sequence
+from hashlib import sha256
 from typing import Union
 
 import irods
@@ -137,3 +139,13 @@ def find_environment_provider(env_providers: list, server_name: str) -> object:
     raise ValueError(
         "Cannot find provider with name {server_name} ensure that the plugin is installed."
     )
+
+def calc_checksum(filepath):
+    if isinstance(filepath, IrodsPath):
+        return filepath.checksum
+    f_hash=sha256()
+    memv=memoryview(bytearray(128*1024))
+    with open(filepath, 'rb', buffering=0) as file:
+        for item in iter(lambda : file.readinto(memv), 0):
+            f_hash.update(memv[:item])
+    return f"sha2:{str(base64.b64encode(f_hash.digest()), encoding='utf-8')}"

--- a/ibridges/util.py
+++ b/ibridges/util.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 from collections.abc import Sequence
 from hashlib import sha256
+from pathlib import Path
 from typing import Union
 
 import irods
@@ -140,7 +141,19 @@ def find_environment_provider(env_providers: list, server_name: str) -> object:
         "Cannot find provider with name {server_name} ensure that the plugin is installed."
     )
 
-def calc_checksum(filepath):
+def calc_checksum(filepath: Union[Path, str, IrodsPath]):
+    """Calculate the checksum for an iRODS dataobject or local file.
+
+    Parameters
+    ----------
+    filepath:
+        Can be either a local path, or an iRODS path
+
+    Returns
+    -------
+        The base64 encoding of the sha256 sum of the object, prefixed by 'sha2:'.
+
+    """
     if isinstance(filepath, IrodsPath):
         return filepath.checksum
     f_hash=sha256()


### PR DESCRIPTION
This PR changes more than expected. There is currently no way to delete aliases either, but that is probably okay for now (just delete your `.ibridges/ibridges_cli.json` file).

Example:

ibridges init ~/.irods/ienv_its.json --alias its
ibridges init ~/.irods/ienv_youth.json --alias youth
ibridges init its  # Old .irodsA gets copied, no password needed
ibridges init youth
ibridges init # Use ~/.irods/irods_environment.json
