### PR TITLE
Fix overwrite / ignore_err flags in upload and download

### DIFF
--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -461,6 +461,8 @@ def _transfer_needed(ipath, lpath, overwrite, ignore_err):
             raise FileExistsError(
                 f"Cannot overwrite {ipath} <-> {lpath} unless overwrite==True. "
                 f"To ignore this error and skip the files use ignore_err==True.")
+        warnings.warn(f"Skipping file/data object {ipath} <-> {lpath} since "
+                      f"both exist and overwrite == False.")
         return False
     if checksums_equal(ipath, lpath):
         return False


### PR DESCRIPTION
Most of the work is simply to add better tests for overwrite and ignore_err flags. The behavior is now when a file/data object already exists is as follows:

overwrite==False, ignore_err=False -> FileExistError
overwrite==True, ignore_err=False -> checksum -> copy
overwrite==False, ignore_err=True -> Skip with warning
overwrite==True, ignore_err=True -> checksum -> copy

Fixes #253 