### PR TITLE
Create the ibridges-gui command

### DIFF
--- a/ibridges/cli/other.py
+++ b/ibridges/cli/other.py
@@ -4,6 +4,7 @@ import sys
 import time
 import traceback
 import subprocess
+import importlib.util
 from pathlib import Path
 
 from ibridges.cli.base import BaseCliCommand
@@ -236,14 +237,12 @@ class CliGui(BaseCliCommand):
     @classmethod
     def run_command(cls, args):
         """Start the GUI."""
-        try:
-            import ibridgesgui # pylint: disable=C0415, W0611 # type: ignore
-            print("'ibridgesgui' is installed")
-        except ModuleNotFoundError:
+        if (spec := importlib.util.find_spec("ibridgesgui")) is not None:
+            subprocess.call(["ibridges-gui"])
+        else:
             print("'ibridgesgui' is not installed. Please install with:")
             print("pip install ibridgesgui")
             sys.exit(234)
 
-        subprocess.call(["ibridges-gui"])
 
 CLI_BULTIN_COMMANDS=[CliShell, CliAlias, CliInit, CliSetup, CliGui]

--- a/ibridges/cli/other.py
+++ b/ibridges/cli/other.py
@@ -244,7 +244,6 @@ class CliGui(BaseCliCommand):
         else:
             parser.error(
                     "'ibridgesgui' is not installed. Please install with\n pip install ibridgesgui")
-            sys.exit(234)
 
 
 CLI_BULTIN_COMMANDS=[CliShell, CliAlias, CliInit, CliSetup, CliGui]

--- a/ibridges/cli/other.py
+++ b/ibridges/cli/other.py
@@ -230,7 +230,7 @@ class CliGui(BaseCliCommand):
 
     @staticmethod
     def run_shell(session, parser, args):
-        """Run init is not available for shell."""
+        """Running the GUI from the shell is not available (yet)."""
         raise NotImplementedError()
 
     @classmethod

--- a/ibridges/cli/other.py
+++ b/ibridges/cli/other.py
@@ -242,8 +242,8 @@ class CliGui(BaseCliCommand):
             from ibridgesgui.__main__ import main  # type: ignore # pylint: disable=E0401, C0415
             main()
         else:
-            parser.error("'ibridgesgui' is not installed. Please install with:")
-            parser.error("pip install ibridgesgui")
+            parser.error(
+                    "'ibridgesgui' is not installed. Please install with\n pip install ibridgesgui")
             sys.exit(234)
 
 

--- a/ibridges/cli/other.py
+++ b/ibridges/cli/other.py
@@ -239,7 +239,7 @@ class CliGui(BaseCliCommand):
         parser = cls.get_parser(argparse.ArgumentParser)
 
         if (importlib.util.find_spec("ibridgesgui")) is not None:
-            from ibridgesgui.__main__ import main  # pylint: disable=E0401, C0415
+            from ibridgesgui.__main__ import main # type: ignore # pylint: disable=E0401, C0415
             main()
         else:
             parser.error("'ibridgesgui' is not installed. Please install with:")

--- a/ibridges/cli/other.py
+++ b/ibridges/cli/other.py
@@ -237,7 +237,7 @@ class CliGui(BaseCliCommand):
     def run_command(cls, args):
         """Start the GUI."""
         try:
-            import ibridgesgui # pylint: disable=C0415, W0611
+            import ibridgesgui # pylint: disable=C0415, W0611 # type: ignore
             print("'ibridgesgui' is installed")
         except ModuleNotFoundError:
             print("'ibridgesgui' is not installed. Please install with:")

--- a/ibridges/cli/other.py
+++ b/ibridges/cli/other.py
@@ -1,7 +1,6 @@
 """Other subcommands that do not fall in a particular category."""
 import argparse
 import importlib.util
-import subprocess
 import sys
 import time
 import traceback
@@ -237,11 +236,14 @@ class CliGui(BaseCliCommand):
     @classmethod
     def run_command(cls, args):
         """Start the GUI."""
+        parser = cls.get_parser(argparse.ArgumentParser)
+
         if (importlib.util.find_spec("ibridgesgui")) is not None:
-            subprocess.call(["ibridges-gui"])
+            from ibridgesgui.__main__ import main  # pylint: disable=E0401, C0415
+            main()
         else:
-            print("'ibridgesgui' is not installed. Please install with:")
-            print("pip install ibridgesgui")
+            parser.error("'ibridgesgui' is not installed. Please install with:")
+            parser.error("pip install ibridgesgui")
             sys.exit(234)
 
 

--- a/ibridges/cli/other.py
+++ b/ibridges/cli/other.py
@@ -1,10 +1,10 @@
 """Other subcommands that do not fall in a particular category."""
 import argparse
+import importlib.util
+import subprocess
 import sys
 import time
 import traceback
-import subprocess
-import importlib.util
 from pathlib import Path
 
 from ibridges.cli.base import BaseCliCommand

--- a/ibridges/cli/other.py
+++ b/ibridges/cli/other.py
@@ -236,10 +236,8 @@ class CliGui(BaseCliCommand):
     @classmethod
     def run_command(cls, args):
         """Start the GUI."""
-        parser = cls.get_parser(argparse.ArgumentParser)
-        #IbridgesConf(parser).set_env(args.irods_env_path_or_alias)
         try:
-            import ibridgesgui
+            import ibridgesgui # pylint: disable=C0415, W0611
             print("'ibridgesgui' is installed")
         except ModuleNotFoundError:
             print("'ibridgesgui' is not installed. Please install with:")
@@ -247,10 +245,5 @@ class CliGui(BaseCliCommand):
             sys.exit(234)
 
         subprocess.call(["ibridges-gui"])
-        #with cli_authenticate(parser) as session:
-        #    if not isinstance(session, Session):
-        #        parser.error(f"Irods session '{session}' is not a session.")
-        #print("ibridges init was succesful.")
-     
 
 CLI_BULTIN_COMMANDS=[CliShell, CliAlias, CliInit, CliSetup, CliGui]

--- a/ibridges/cli/other.py
+++ b/ibridges/cli/other.py
@@ -239,7 +239,7 @@ class CliGui(BaseCliCommand):
         parser = cls.get_parser(argparse.ArgumentParser)
 
         if (importlib.util.find_spec("ibridgesgui")) is not None:
-            from ibridgesgui.__main__ import main # type: ignore # pylint: disable=E0401, C0415
+            from ibridgesgui.__main__ import main  # type: ignore # pylint: disable=E0401, C0415
             main()
         else:
             parser.error("'ibridgesgui' is not installed. Please install with:")

--- a/ibridges/cli/other.py
+++ b/ibridges/cli/other.py
@@ -237,7 +237,7 @@ class CliGui(BaseCliCommand):
     @classmethod
     def run_command(cls, args):
         """Start the GUI."""
-        if (spec := importlib.util.find_spec("ibridgesgui")) is not None:
+        if (importlib.util.find_spec("ibridgesgui")) is not None:
             subprocess.call(["ibridges-gui"])
         else:
             print("'ibridgesgui' is not installed. Please install with:")

--- a/ibridges/cli/other.py
+++ b/ibridges/cli/other.py
@@ -3,6 +3,7 @@ import argparse
 import sys
 import time
 import traceback
+import subprocess
 from pathlib import Path
 
 from ibridges.cli.base import BaseCliCommand
@@ -220,4 +221,36 @@ class CliSetup(BaseCliCommand):
             with open(args.output, "w", encoding="utf-8") as handle:
                 handle.write(json_str)
 
-CLI_BULTIN_COMMANDS=[CliShell, CliAlias, CliInit, CliSetup]
+class CliGui(BaseCliCommand):
+    """Subcommand to open the iBridges GUI."""
+
+    names = ["gui"]
+    description = "Start the iBridges GUI."
+    examples = ["gui"]
+
+    @staticmethod
+    def run_shell(session, parser, args):
+        """Run init is not available for shell."""
+        raise NotImplementedError()
+
+    @classmethod
+    def run_command(cls, args):
+        """Start the GUI."""
+        parser = cls.get_parser(argparse.ArgumentParser)
+        #IbridgesConf(parser).set_env(args.irods_env_path_or_alias)
+        try:
+            import ibridgesgui
+            print("'ibridgesgui' is installed")
+        except ModuleNotFoundError:
+            print("'ibridgesgui' is not installed. Please install with:")
+            print("pip install ibridgesgui")
+            sys.exit(234)
+
+        subprocess.call(["ibridges-gui"])
+        #with cli_authenticate(parser) as session:
+        #    if not isinstance(session, Session):
+        #        parser.error(f"Irods session '{session}' is not a session.")
+        #print("ibridges init was succesful.")
+     
+
+CLI_BULTIN_COMMANDS=[CliShell, CliAlias, CliInit, CliSetup, CliGui]


### PR DESCRIPTION
A very simple way to check whether the GUI is installed and then call it or inform the users how to install it.
To be extended with:

- [x] Check whether plugins for the GUI are detected
- [ ] (Maybe) Create an option to pass the environment for which the GUI should be openend --> Needs a lot of work on the GUI side. @qubixes Should we do that? --> move to later when we fixed https://github.com/iBridges-for-iRODS/iBridges-GUI/issues/318