### PR TITLE
Improve the interface for __setitem__ for metadata

### DIFF
--- a/docker/irods_client/tests/test_meta.py
+++ b/docker/irods_client/tests/test_meta.py
@@ -62,10 +62,16 @@ def test_meta(item_name, request):
 
     meta.add("x", "y")
     meta.add("y", "z")
-    meta.set("y", "x")
+    meta["y"] = "x"
     assert "x" in meta
     assert ("y", "z") not in meta
     assert ("y", "x") in meta
+
+    meta["y"] = [["x", "u"], ["y", "u"]]
+    assert ("y", "x") in meta
+    assert ("y", "y") in meta
+    with pytest.raises(ValueError):
+        meta["y"] = "z"
     meta.clear()
 
 @mark.parametrize("item_name", ["collection", "dataobject"])

--- a/docker/irods_client/tests/test_meta.py
+++ b/docker/irods_client/tests/test_meta.py
@@ -149,6 +149,8 @@ def test_metadata_setitem(item_name, request):
     meta["key", "value"] = "other_units"
     assert ("key", "value", "units") not in meta
     assert ("key", "value", "other_units") in meta
+    meta["key", "other_value"] = "units"
+    assert ("key", "value", "other_units") in meta
 
     meta.add("key", "value", "even_units")
     assert len(meta) == 3

--- a/docker/irods_client/tests/test_meta.py
+++ b/docker/irods_client/tests/test_meta.py
@@ -72,6 +72,13 @@ def test_meta(item_name, request):
     assert ("y", "y") in meta
     with pytest.raises(ValueError):
         meta["y"] = "z"
+    assert ("y", "x") in meta
+    assert ("y", "y") in meta
+    with pytest.raises(ValueError):
+        meta["y"] = [["a", "b", "c"]]
+    meta.delete(key="y")
+    with pytest.raises(ValueError):
+        meta["y"] = "a", "b", "c"
     meta.clear()
 
 @mark.parametrize("item_name", ["collection", "dataobject"])

--- a/docker/irods_client/tests/test_meta.py
+++ b/docker/irods_client/tests/test_meta.py
@@ -143,15 +143,27 @@ def test_metadata_setitem(item_name, request):
     meta = MetaData(item)
     meta.clear()
 
-    meta.add("some_key", "some_value", "some_units")
-    meta["some_key"] = ("some_key", "new_value", "new_units")
-    meta["some_key"] = ("some_key", "new_value")
+    meta["key"] = "value", "units"
+    assert ("key", "value", "units") in meta
 
-    with pytest.raises(TypeError):
-        meta["some_key"] = "new_value"
+    meta["key", "value"] = "other_units"
+    assert ("key", "value", "units") not in meta
+    assert ("key", "value", "other_units") in meta
+
+    meta.add("key", "value", "even_units")
+    assert len(meta) == 2
+    meta["key"] = "new_value"
+    assert ("key", "value", "other_units") not in meta
+    assert len(meta) == 1
+
+    meta["key2"] = "value2"
+    assert len(meta) == 2
 
     with pytest.raises(ValueError):
-        meta["some_key"] = ("some_key", "new_value")
+        meta["some_key", "some_value", "some_units"] = ""
+
+    with pytest.raises(ValueError):
+        meta["some_key", "some_value"] = "new_value", "new_units"
 
 
 @mark.parametrize("item_name", ["collection", "dataobject"])

--- a/docker/irods_client/tests/test_meta.py
+++ b/docker/irods_client/tests/test_meta.py
@@ -151,13 +151,15 @@ def test_metadata_setitem(item_name, request):
     assert ("key", "value", "other_units") in meta
 
     meta.add("key", "value", "even_units")
-    assert len(meta) == 2
-    meta["key"] = "new_value"
-    assert ("key", "value", "other_units") not in meta
-    assert len(meta) == 1
+    assert len(meta) == 3
+    with pytest.raises(ValueError):
+        meta["key"] = "new_value"
+
+    with pytest.raises(ValueError):
+        meta["key", "value"] = "another_units"
 
     meta["key2"] = "value2"
-    assert len(meta) == 2
+    assert len(meta) == 4
 
     with pytest.raises(ValueError):
         meta["some_key", "some_value", "some_units"] = ""

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -50,13 +50,14 @@ To add metadata, you always need to provide a key and a value, the units are opt
 Set metadata
 ------------
 
-The :meth:`MetaData.set` method differs from the add method by removing all other entries with the
-same key first. This mirrors the implementation of the `iCommands <https://rdm-docs.icts.kuleuven.be/mango/clients/icommands.html#adding-metadata>`__
+You can use the brackets ``[]`` to set a key or key/value pair to one value or value/unit pair.
+This mirrors the implementation of the `iCommands <https://rdm-docs.icts.kuleuven.be/mango/clients/icommands.html#adding-metadata>`__
 :code:`imeta set`.
 
 .. code-block:: python
 
-    meta.set('ExistingKey', 'Value', 'Unit')
+    meta["ExistingKey"] = 'Value', 'Unit'
+    meta["ExistingKey", "Value"] = "New_Unit"
 
 
 Find metadata items

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -50,7 +50,8 @@ To add metadata, you always need to provide a key and a value, the units are opt
 Set metadata
 ------------
 
-You can use the brackets ``[]`` to set a key or key/value pair.
+You can use the brackets ``[]`` to set a key or key/value pair. The following code creates two entries:
+(ExistingKey, Value, Unit) and (ExistingKey, NewValue, NewUnit). 
 
 
 .. code-block:: python
@@ -58,13 +59,13 @@ You can use the brackets ``[]`` to set a key or key/value pair.
     meta["ExistingKey"] = "Value", "Unit"
     meta["ExistingKey", "New_Value"] = "New_Unit"
 
-This notation will only change/set one triplet at the same time. So, for example the following will throw an error:
+The single assignment notation will only change/set one triplet at the same time. So, for example the following will throw an error:
 
 .. code-block:: python
 
     meta["ExistingKey"] = "Other_Value", "Other_Unit"
 
-If you want to remove all entries with the key ``ExistingKey``, then you can use the double bracket notation:
+If you want to remove all entries with the key ``ExistingKey`` and set it to one or more new entries, then you can use the double bracket notation:
 
 .. code-block:: python
 

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -50,15 +50,29 @@ To add metadata, you always need to provide a key and a value, the units are opt
 Set metadata
 ------------
 
-You can use the brackets ``[]`` to set a key or key/value pair to one value or value/unit pair.
-This mirrors the implementation of the `iCommands <https://rdm-docs.icts.kuleuven.be/mango/clients/icommands.html#adding-metadata>`__
-:code:`imeta set`.
+You can use the brackets ``[]`` to set a key or key/value pair.
+
 
 .. code-block:: python
 
-    meta["ExistingKey"] = 'Value', 'Unit'
-    meta["ExistingKey", "Value"] = "New_Unit"
+    meta["ExistingKey"] = "Value", "Unit"
+    meta["ExistingKey", "New_Value"] = "New_Unit"
 
+This notation will only change/set one triplet at the same time. So, for example the following will throw an error:
+
+.. code-block:: python
+
+    meta["ExistingKey"] = "Other_Value", "Other_Unit"
+
+If you want to remove all entries with the key ``ExistingKey``, then you can use the double bracket notation:
+
+.. code-block:: python
+
+    meta["ExistingKey"] = [["Other_Value", "Other_Unit"]]
+
+
+This notation mirrors the implementation of the `iCommands <https://rdm-docs.icts.kuleuven.be/mango/clients/icommands.html#adding-metadata>`__
+:code:`imeta set`.
 
 Find metadata items
 -------------------

--- a/ibridges/cli/shell.py
+++ b/ibridges/cli/shell.py
@@ -212,7 +212,7 @@ def complete_ipath(session, text, line, collections_only=False):  # pylint: disa
 
     base_arg = args[-1]
     base_completion = []
-    if args[-1].startswith("irods"[:len(args[-1])]):
+    if args[-1].startswith("irods:"[:len(args[-1])]):
         if len(args[-1]) < len("irods:"):
             base_completion = [text[:len(text)-len(args[-1])] + "irods:"]
         else:

--- a/ibridges/interactive.py
+++ b/ibridges/interactive.py
@@ -91,7 +91,6 @@ def _from_pw_file(irods_env_path, irodsa_backup: Optional[str] = None, **kwargs)
     except IndexError:
         print("INFO: The cached password in ~/.irods/.irodsA has been corrupted")
     except PasswordError:
-        print(irodsa_backup)
         if irodsa_backup is not None:
             with open(DEFAULT_IRODSA_PATH, "w", encoding="utf-8") as handle:
                 handle.write(irodsa_backup)

--- a/ibridges/meta.py
+++ b/ibridges/meta.py
@@ -157,7 +157,8 @@ class MetaData:
             )
         return all_items[0]
 
-    def __setitem__(self, key: Union[str, Sequence[Union[str, None]]], other: Sequence[str]):
+    def __setitem__(self, key: Union[str, Sequence[Union[str, None]]],
+                    *other: Union[Sequence[str], str]):
         """Set metadata items like a dictionary of tuples.
 
         Parameters
@@ -180,13 +181,13 @@ class MetaData:
         >>> meta["key"] = ("new_key", "old_value")
 
         """
-        if isinstance(other, str):
-            raise TypeError(
-                "Cannot set the metadata item to a single string value. "
-                f'Use meta[{key}].key = "{other}" to change only the key '
-                "for example."
-            )
-        self[key].update(*other)
+        if key in self:
+            try:
+                self[key].update(key, *other)
+            except ValueError:
+                pass
+        else:
+            self.add(key, *other)
 
     def add(self, key: str, value: str, units: Optional[str] = ""):
         """Add metadata to an item.
@@ -490,7 +491,7 @@ class MetaDataItem:
         yield self.value
         yield self.units
 
-    def update(self, new_key: str, new_value: str, new_units: Optional[str] = ""):
+    def update(self, new_key: str, new_value: str, new_units: str = ""):
         """Update the metadata item changing the key/value/units.
 
         Parameters

--- a/ibridges/meta.py
+++ b/ibridges/meta.py
@@ -195,7 +195,7 @@ class MetaData:
                              "meta['key'] = 'value', 'units' or meta['key', 'value'] = 'units'.")
 
         try:
-            item = self[*key]
+            item = self.__getitem__(key)
             item.remove()
         except KeyError:
             pass

--- a/ibridges/meta.py
+++ b/ibridges/meta.py
@@ -201,9 +201,9 @@ class MetaData:
         else:
             for subset in other:
                 if not all(isinstance(s, str) for s in subset):
-                     raise ValueError(
-                         "Badly formed argument to __setitem__: should be set to either string,"
-                         " list of strings or list of list of strings.")
+                    raise ValueError(
+                        "Badly formed argument to __setitem__: should be set to either string,"
+                        " list of strings or list of list of strings.")
                 if len(subset) + len(key) > 3:
                     raise ValueError(
                         f"Too many items to create metadata triple {subset} + {key}. Use "

--- a/ibridges/meta.py
+++ b/ibridges/meta.py
@@ -158,7 +158,7 @@ class MetaData:
         return all_items[0]
 
     def __setitem__(self, key: Union[str, Sequence[Union[str, None]]],
-                    *other: Union[Sequence[str], str]):
+                    other: Union[Sequence[str], str]):
         """Set metadata items like a dictionary of tuples.
 
         Parameters
@@ -177,17 +177,30 @@ class MetaData:
 
         Examples
         --------
-        >>> meta["key"] = ("key", "new_value", "new_units")
-        >>> meta["key"] = ("new_key", "old_value")
+        >>> meta["key"] = "units"
+        >>> meta["key"] = "units", "values"
+        >>> meta["key", "value"] = "units"
 
         """
+        if isinstance(other, str):
+            other = [other]
+        if isinstance(key, str):
+            key = [key]
+
+        if len(key) < 1 or len(key) > 2:
+            raise ValueError("Use either one or two values within the brackets [], for example "
+                             f"meta['some_key', 'some_value'] = 'some_units', got: {key}")
+        if len(other) + len(key) > 3:
+            raise ValueError(f"Too many items to create metadata triple {other+key}. Use "
+                             "meta['key'] = 'value', 'units' or meta['key', 'value'] = 'units'.")
+
         if key in self:
             try:
-                self[key].update(key, *other)
+                self[*key].update(*key, *other)
             except ValueError:
                 pass
         else:
-            self.add(key, *other)
+            self.add(*key, *other)
 
     def add(self, key: str, value: str, units: Optional[str] = ""):
         """Add metadata to an item.

--- a/ibridges/meta.py
+++ b/ibridges/meta.py
@@ -195,12 +195,8 @@ class MetaData:
                              "meta['key'] = 'value', 'units' or meta['key', 'value'] = 'units'.")
 
         if key in self:
-            try:
-                self[*key].update(*key, *other)
-            except ValueError:
-                pass
-        else:
-            self.add(*key, *other)
+            self.delete(*key)
+        self.add(*key, *other)
 
     def add(self, key: str, value: str, units: Optional[str] = ""):
         """Add metadata to an item.

--- a/ibridges/meta.py
+++ b/ibridges/meta.py
@@ -187,7 +187,7 @@ class MetaData:
         if isinstance(key, str):
             key = [key]
 
-        if len(key) < 1 or len(key) > 2:
+        if len(key) > 2:
             raise ValueError("Use either one or two values within the brackets [], for example "
                              f"meta['some_key', 'some_value'] = 'some_units', got: {key}")
         if len(other) + len(key) > 3:

--- a/ibridges/meta.py
+++ b/ibridges/meta.py
@@ -219,9 +219,7 @@ class MetaData:
 
         This will never overwrite an existing entry. If the triplet already exists
         it will throw an error instead. Note that entries are only considered the same
-        if all of the key, value and units are the same. Alternatively you can use the
-        brackets [] to remove all entries with the same key, before adding the
-        new entry, see :meth:`__setitem__`.
+        if all of the key, value and units are the same.
 
         Parameters
         ----------

--- a/ibridges/meta.py
+++ b/ibridges/meta.py
@@ -198,16 +198,15 @@ class MetaData:
                                  f" exist. Use meta[{key}] = [{other}] to remove all current values"
                                  f" with new values.")
             other = [other]  # type: ignore
-        else:
-            for subset in other:
-                if not all(isinstance(s, str) for s in subset):
-                    raise ValueError(
-                        "Badly formed argument to __setitem__: should be set to either string,"
-                        " list of strings or list of list of strings.")
-                if len(subset) + len(key) > 3:
-                    raise ValueError(
-                        f"Too many items to create metadata triple {subset} + {key}. Use "
-                        "meta['key'] = 'value', 'units' or meta['key', 'value'] = 'units'.")
+        for subset in other:
+            if not all(isinstance(s, str) for s in subset):
+                raise ValueError(
+                    "Badly formed argument to __setitem__: should be set to either string,"
+                    " list of strings or list of list of strings.")
+            if len(subset) + len(key) > 3:
+                raise ValueError(
+                    f"Too many items to create metadata triple {subset} + {key}. Use "
+                    "meta['key'] = 'value', 'units' or meta['key', 'value'] = 'units'.")
 
         for item in all_items:
             item.remove()

--- a/ibridges/meta.py
+++ b/ibridges/meta.py
@@ -194,8 +194,12 @@ class MetaData:
             raise ValueError(f"Too many items to create metadata triple {other} + {key}. Use "
                              "meta['key'] = 'value', 'units' or meta['key', 'value'] = 'units'.")
 
-        if key in self:
-            self.delete(*key)
+        try:
+            item = self[*key]
+            item.remove()
+        except KeyError:
+            pass
+
         self.add(*key, *other)
 
     def add(self, key: str, value: str, units: Optional[str] = ""):

--- a/ibridges/meta.py
+++ b/ibridges/meta.py
@@ -158,7 +158,7 @@ class MetaData:
         return all_items[0]
 
     def __setitem__(self, key: Union[str, Sequence[str]],
-                    other: Union[str, Sequence[str]]):
+                    other: Union[str, Sequence[str], Sequence[Sequence[str]]]):
         """Set metadata items like a dictionary of tuples.
 
         Parameters
@@ -190,17 +190,30 @@ class MetaData:
         if len(key) > 2:
             raise ValueError("Use either one or two values within the brackets [], for example "
                              f"meta['some_key', 'some_value'] = 'some_units', got: {key}")
-        if len(other) + len(key) > 3:
-            raise ValueError(f"Too many items to create metadata triple {other} + {key}. Use "
-                             "meta['key'] = 'value', 'units' or meta['key', 'value'] = 'units'.")
 
-        try:
-            item = self.__getitem__(key)
+        all_items = self.find_all(*key)
+        if all(isinstance(o, str) for o in other):
+            if len(all_items) > 1:
+                raise ValueError(f"Cannot set item with '{key}' to single item: multiple entries"
+                                 f" exist. Use meta[{key}] = [{other}] to remove all current values"
+                                 f" with new values.")
+            other = [other]
+        else:
+            for subset in other:
+                if not all(isinstance(s, str) for s in subset):
+                     raise ValueError(
+                         "Badly formed argument to __setitem__: should be set to either string,"
+                         " list of strings or list of list of strings.")
+                if len(subset) + len(key) > 3:
+                    raise ValueError(
+                        f"Too many items to create metadata triple {subset} + {key}. Use "
+                        "meta['key'] = 'value', 'units' or meta['key', 'value'] = 'units'.")
+
+        for item in all_items:
             item.remove()
-        except KeyError:
-            pass
 
-        self.add(*key, *other)
+        for sub in other:
+            self.add(*key, *sub)
 
     def add(self, key: str, value: str, units: Optional[str] = ""):
         """Add metadata to an item.

--- a/ibridges/meta.py
+++ b/ibridges/meta.py
@@ -204,8 +204,8 @@ class MetaData:
         This will never overwrite an existing entry. If the triplet already exists
         it will throw an error instead. Note that entries are only considered the same
         if all of the key, value and units are the same. Alternatively you can use the
-        :meth:`set` method to remove all entries with the same key, before adding the
-        new entry.
+        brackets [] to remove all entries with the same key, before adding the
+        new entry, see :meth:`__setitem__`.
 
         Parameters
         ----------
@@ -251,6 +251,9 @@ class MetaData:
         the same key will be deleted before adding the new entry. An alternative
         is using the :meth:`add` method to only add to the metadata entries and not
         delete them.
+
+        This method is deprecated, and will be removed in the future. You should use
+        the bracket [] notation instead: meta[key] = value or meta[key] = value, units.
 
         Parameters
         ----------

--- a/ibridges/meta.py
+++ b/ibridges/meta.py
@@ -177,8 +177,8 @@ class MetaData:
 
         Examples
         --------
-        >>> meta["key"] = "units"
-        >>> meta["key"] = "units", "values"
+        >>> meta["key"] = "values"
+        >>> meta["key"] = "values", "units"
         >>> meta["key", "value"] = "units"
 
         """

--- a/ibridges/meta.py
+++ b/ibridges/meta.py
@@ -157,8 +157,8 @@ class MetaData:
             )
         return all_items[0]
 
-    def __setitem__(self, key: Union[str, Sequence[Union[str, None]]],
-                    other: Union[Sequence[str], str]):
+    def __setitem__(self, key: Union[str, Sequence[str]],
+                    other: Union[str, Sequence[str]]):
         """Set metadata items like a dictionary of tuples.
 
         Parameters
@@ -191,7 +191,7 @@ class MetaData:
             raise ValueError("Use either one or two values within the brackets [], for example "
                              f"meta['some_key', 'some_value'] = 'some_units', got: {key}")
         if len(other) + len(key) > 3:
-            raise ValueError(f"Too many items to create metadata triple {other+key}. Use "
+            raise ValueError(f"Too many items to create metadata triple {other} + {key}. Use "
                              "meta['key'] = 'value', 'units' or meta['key', 'value'] = 'units'.")
 
         if key in self:

--- a/ibridges/meta.py
+++ b/ibridges/meta.py
@@ -197,7 +197,7 @@ class MetaData:
                 raise ValueError(f"Cannot set item with '{key}' to single item: multiple entries"
                                  f" exist. Use meta[{key}] = [{other}] to remove all current values"
                                  f" with new values.")
-            other = [other]
+            other = [other]  # type: ignore
         else:
             for subset in other:
                 if not all(isinstance(s, str) for s in subset):

--- a/tutorials/04-Metadata.ipynb
+++ b/tutorials/04-Metadata.ipynb
@@ -314,7 +314,7 @@
    "id": "5dbc03e9-3b30-4b0d-9b7c-f3be1403bf75",
    "metadata": {},
    "source": [
-    "Another way to set a metadata key to a new value and units is the `set` function."
+    "Another way to set a metadata key to a new value and units is with the bracket `[]` notation."
    ]
   },
   {
@@ -334,7 +334,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "obj_meta.set('Author', 'person')\n",
+    "obj_meta['Author'] = 'person'\n",
     "print(obj_meta)"
    ]
   },
@@ -353,7 +353,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "obj_meta.set('Key', 'OtherValue')\n",
+    "obj_meta['Key'] = 'OtherValue'\n",
     "print(obj_meta)"
    ]
   },
@@ -900,7 +900,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -914,7 +914,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The original implementation was simply confusing and cumbersome to work with, at least for me.

This proposal does break compatibility, but I think this is much more understandable than what was happening before.