### PR TITLE
add catch all err clause to obj_put and obj_get

### DIFF
--- a/docker/irods_client/tests/test_data_ops.py
+++ b/docker/irods_client/tests/test_data_ops.py
@@ -56,7 +56,7 @@ def test_upload_download_dataset(session, testdata):
     ops = upload(session, testdata/"plant.rtf", ipath, overwrite=False, on_err='warn')
     assert len(ops.upload) == 0
     
-    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=True, on_err='skip')
+    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=True, on_err='skip', dry_run=True)
     assert len(ops.upload) == 1
     ops = upload(session, testdata/"plant.rtf", ipath, overwrite=True, on_err='warn')
     assert len(ops.upload) == 1
@@ -73,13 +73,13 @@ def test_upload_download_dataset(session, testdata):
     with pytest.raises(FileExistsError):
         download(session, ipath, lpath)
     ops = download(session, ipath, lpath, overwrite=False, on_err='skip')
-    #assert len(ops.download) == 0
-    #ops = download(session, ipath, lpath, overwrite=False, on_err='warn')
-    #assert len(ops.download) == 0
+    assert len(ops.download) == 0
+    ops = download(session, ipath, lpath, overwrite=False, on_err='warn')
+    assert len(ops.download) == 0
     with ipath.open("w") as handle:
         handle.write("test".encode())
-    #ops = download(session, ipath, lpath, overwrite=True)
-    #assert len(ops.download) == 1
+    ops = download(session, ipath, lpath, overwrite=True)
+    assert len(ops.download) == 1
     ipath.remove()
     lpath.unlink()
 

--- a/docker/irods_client/tests/test_data_ops.py
+++ b/docker/irods_client/tests/test_data_ops.py
@@ -51,15 +51,17 @@ def test_upload_download_dataset(session, testdata):
     assert len(ops.upload) == 0
     with ipath.open("w") as handle:
         handle.write("test".encode())
-    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=False, on_err='skip')
+    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=False, on_error='skip')
     assert len(ops.upload) == 0
-    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=False, on_err='warn')
-    assert len(ops.upload) == 0
+    with pytest.warns(UserWarning):
+        ops = upload(session, testdata/"plant.rtf", ipath, overwrite=False, on_error='warn')
+        assert len(ops.upload) == 0
     
-    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=True, on_err='skip', dry_run=True)
+    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=True, on_error='skip', dry_run=True)
     assert len(ops.upload) == 1
-    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=True, on_err='warn')
-    assert len(ops.upload) == 1
+    with pytest.warns(UserWarning):
+        ops = upload(session, testdata/"plant.rtf", ipath, overwrite=True, on_error='warn')
+        assert len(ops.upload) == 1
 
     # Test downloading it back
     ops = download(session, ipath, testdata/"plant.rtf.copy", overwrite=True)
@@ -72,10 +74,11 @@ def test_upload_download_dataset(session, testdata):
     assert len(ops.download) == 0
     with pytest.raises(FileExistsError):
         download(session, ipath, lpath)
-    ops = download(session, ipath, lpath, overwrite=False, on_err='skip')
+    ops = download(session, ipath, lpath, overwrite=False, on_error='skip')
     assert len(ops.download) == 0
-    ops = download(session, ipath, lpath, overwrite=False, on_err='warn')
-    assert len(ops.download) == 0
+    with pytest.warns(UserWarning):
+        ops = download(session, ipath, lpath, overwrite=False, on_error='warn')
+        assert len(ops.download) == 0
     with ipath.open("w") as handle:
         handle.write("test".encode())
     ops = download(session, ipath, lpath, overwrite=True)
@@ -98,7 +101,7 @@ def test_upload_download_collection(session, testdata, tmpdir):
     # Check overwrite and ignore_err parameters
     with pytest.raises(DataObjectExistsError):
         upload(session, testdata, ipath)
-    ops = upload(session, testdata, ipath, on_err="skip")
+    ops = upload(session, testdata, ipath, on_error="skip")
     _check_count(ops, [0, 0, 0, 0])
     bunny_ipath = (ipath / "testdata" / "bunny.rtf")
     bunny_ipath.remove()
@@ -131,9 +134,9 @@ def test_upload_download_collection(session, testdata, tmpdir):
     _check_count(ops, [0, 0, 0, 0])
     with bunny_ipath.open("w") as handle:
         handle.write("testxx".encode())
-    ops = download(session, ipath, tmpdir/"test", on_err='skip')
+    ops = download(session, ipath, tmpdir/"test", on_error='skip')
     _check_count(ops, [0, 0, 0, 0])
-    ops = download(session, ipath, tmpdir/"test", on_err='warn')
+    ops = download(session, ipath, tmpdir/"test", on_error='warn')
     _check_count(ops, [0, 0, 0, 0])
     ops = download(session, ipath, tmpdir/"test", overwrite='skip', dry_run=True)
     _check_count(ops, [0, 0, 1, 0])

--- a/docker/irods_client/tests/test_data_ops.py
+++ b/docker/irods_client/tests/test_data_ops.py
@@ -51,9 +51,13 @@ def test_upload_download_dataset(session, testdata):
     assert len(ops.upload) == 0
     with ipath.open("w") as handle:
         handle.write("test".encode())
-    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=False, ignore_err=True)
+    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=False, on_err='skip')
     assert len(ops.upload) == 0
-    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=True, ignore_err=True)
+    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=False, on_err='warn')
+    assert len(ops.upload) == 0
+    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=True, on_err='skip')
+    assert len(ops.upload) == 1
+    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=True, on_err='warn')
     assert len(ops.upload) == 1
 
     # Test downloading it back
@@ -67,7 +71,9 @@ def test_upload_download_dataset(session, testdata):
     assert len(ops.download) == 0
     with pytest.raises(FileExistsError):
         download(session, ipath, lpath)
-    ops = download(session, ipath, lpath, overwrite=False, ignore_err=True)
+    ops = download(session, ipath, lpath, overwrite=False, on_err='skip')
+    assert len(ops.download) == 0
+    ops = download(session, ipath, lpath, overwrite=False, on_err='warn')
     assert len(ops.download) == 0
     with ipath.open("w") as handle:
         handle.write("test".encode())

--- a/docker/irods_client/tests/test_data_ops.py
+++ b/docker/irods_client/tests/test_data_ops.py
@@ -59,9 +59,8 @@ def test_upload_download_dataset(session, testdata):
     
     ops = upload(session, testdata/"plant.rtf", ipath, overwrite=True, on_error='skip', dry_run=True)
     assert len(ops.upload) == 1
-    with pytest.warns(UserWarning):
-        ops = upload(session, testdata/"plant.rtf", ipath, overwrite=True, on_error='warn')
-        assert len(ops.upload) == 1
+    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=True, on_error='warn')
+    assert len(ops.upload) == 1
 
     # Test downloading it back
     ops = download(session, ipath, testdata/"plant.rtf.copy", overwrite=True)

--- a/docker/irods_client/tests/test_data_ops.py
+++ b/docker/irods_client/tests/test_data_ops.py
@@ -131,9 +131,13 @@ def test_upload_download_collection(session, testdata, tmpdir):
     _check_count(ops, [0, 0, 0, 0])
     with bunny_ipath.open("w") as handle:
         handle.write("testxx".encode())
-    ops = download(session, ipath, tmpdir/"test", ignore_err=True)
+    ops = download(session, ipath, tmpdir/"test", on_err='skip')
     _check_count(ops, [0, 0, 0, 0])
-    ops = download(session, ipath, tmpdir/"test", overwrite=True)
+    ops = download(session, ipath, tmpdir/"test", on_err='warn')
+    _check_count(ops, [0, 0, 0, 0])
+    ops = download(session, ipath, tmpdir/"test", overwrite='skip', dry_run=True)
+    _check_count(ops, [0, 0, 1, 0])
+    ops = download(session, ipath, tmpdir/"test", overwrite='warn')
     _check_count(ops, [0, 0, 1, 0])
     ipath.remove()
 

--- a/docker/irods_client/tests/test_data_ops.py
+++ b/docker/irods_client/tests/test_data_ops.py
@@ -51,8 +51,8 @@ def test_upload_download_dataset(session, testdata):
     assert len(ops.upload) == 0
     with ipath.open("w") as handle:
         handle.write("test".encode())
-    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=False, on_err='skip')
-    assert len(ops.upload) == 0
+    #ops = upload(session, testdata/"plant.rtf", ipath, overwrite=False, on_err='skip')
+    #assert len(ops.upload) == 0
     #ops = upload(session, testdata/"plant.rtf", ipath, overwrite=False, on_err='warn')
     #assert len(ops.upload) == 0
     

--- a/docker/irods_client/tests/test_data_ops.py
+++ b/docker/irods_client/tests/test_data_ops.py
@@ -53,8 +53,9 @@ def test_upload_download_dataset(session, testdata):
         handle.write("test".encode())
     ops = upload(session, testdata/"plant.rtf", ipath, overwrite=False, on_err='skip')
     assert len(ops.upload) == 0
-    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=False, on_err='warn')
-    assert len(ops.upload) == 0
+    #ops = upload(session, testdata/"plant.rtf", ipath, overwrite=False, on_err='warn')
+    #assert len(ops.upload) == 0
+    
     ops = upload(session, testdata/"plant.rtf", ipath, overwrite=True, on_err='skip')
     assert len(ops.upload) == 1
     ops = upload(session, testdata/"plant.rtf", ipath, overwrite=True, on_err='warn')
@@ -97,7 +98,7 @@ def test_upload_download_collection(session, testdata, tmpdir):
     # Check overwrite and ignore_err parameters
     with pytest.raises(DataObjectExistsError):
         upload(session, testdata, ipath)
-    ops = upload(session, testdata, ipath, ignore_err=True)
+    ops = upload(session, testdata, ipath, on_err="skip")
     _check_count(ops, [0, 0, 0, 0])
     bunny_ipath = (ipath / "testdata" / "bunny.rtf")
     bunny_ipath.remove()

--- a/docker/irods_client/tests/test_data_ops.py
+++ b/docker/irods_client/tests/test_data_ops.py
@@ -56,10 +56,10 @@ def test_upload_download_dataset(session, testdata):
     ops = upload(session, testdata/"plant.rtf", ipath, overwrite=False, on_err='warn')
     assert len(ops.upload) == 0
     
-    #ops = upload(session, testdata/"plant.rtf", ipath, overwrite=True, on_err='skip')
-    #assert len(ops.upload) == 1
-    #ops = upload(session, testdata/"plant.rtf", ipath, overwrite=True, on_err='warn')
-    #assert len(ops.upload) == 1
+    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=True, on_err='skip')
+    assert len(ops.upload) == 1
+    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=True, on_err='warn')
+    assert len(ops.upload) == 1
 
     # Test downloading it back
     ops = download(session, ipath, testdata/"plant.rtf.copy", overwrite=True)

--- a/docker/irods_client/tests/test_data_ops.py
+++ b/docker/irods_client/tests/test_data_ops.py
@@ -51,15 +51,15 @@ def test_upload_download_dataset(session, testdata):
     assert len(ops.upload) == 0
     with ipath.open("w") as handle:
         handle.write("test".encode())
-    #ops = upload(session, testdata/"plant.rtf", ipath, overwrite=False, on_err='skip')
-    #assert len(ops.upload) == 0
-    #ops = upload(session, testdata/"plant.rtf", ipath, overwrite=False, on_err='warn')
-    #assert len(ops.upload) == 0
+    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=False, on_err='skip')
+    assert len(ops.upload) == 0
+    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=False, on_err='warn')
+    assert len(ops.upload) == 0
     
-    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=True, on_err='skip')
-    assert len(ops.upload) == 1
-    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=True, on_err='warn')
-    assert len(ops.upload) == 1
+    #ops = upload(session, testdata/"plant.rtf", ipath, overwrite=True, on_err='skip')
+    #assert len(ops.upload) == 1
+    #ops = upload(session, testdata/"plant.rtf", ipath, overwrite=True, on_err='warn')
+    #assert len(ops.upload) == 1
 
     # Test downloading it back
     ops = download(session, ipath, testdata/"plant.rtf.copy", overwrite=True)
@@ -73,13 +73,13 @@ def test_upload_download_dataset(session, testdata):
     with pytest.raises(FileExistsError):
         download(session, ipath, lpath)
     ops = download(session, ipath, lpath, overwrite=False, on_err='skip')
-    assert len(ops.download) == 0
-    ops = download(session, ipath, lpath, overwrite=False, on_err='warn')
-    assert len(ops.download) == 0
+    #assert len(ops.download) == 0
+    #ops = download(session, ipath, lpath, overwrite=False, on_err='warn')
+    #assert len(ops.download) == 0
     with ipath.open("w") as handle:
         handle.write("test".encode())
-    ops = download(session, ipath, lpath, overwrite=True)
-    assert len(ops.download) == 1
+    #ops = download(session, ipath, lpath, overwrite=True)
+    #assert len(ops.download) == 1
     ipath.remove()
     lpath.unlink()
 

--- a/ibridges/cli/__main__.py
+++ b/ibridges/cli/__main__.py
@@ -31,6 +31,6 @@ def main():
         return
     args = parser.parse_args(sys.argv[1:])
     args.func(args)
-    
+
 if __name__ == "__main__":
     main()

--- a/ibridges/cli/__main__.py
+++ b/ibridges/cli/__main__.py
@@ -31,6 +31,6 @@ def main():
         return
     args = parser.parse_args(sys.argv[1:])
     args.func(args)
-
+    
 if __name__ == "__main__":
     main()

--- a/ibridges/cli/data_operations.py
+++ b/ibridges/cli/data_operations.py
@@ -162,7 +162,7 @@ class CliDownload(BaseCliCommand):
         """Download the data object or collection."""
         if args.on_error not in ["fail", "warn", "skip"]:
             parser.error(
-                f"'on-error': Unknonw keyword {args.on_error}, choose 'fail', 'warn' or 'skip'")
+                f"'on-error': Unknown keyword {args.on_error}, choose 'fail', 'warn' or 'skip'")
         ipath = parse_remote(args.remote_path, session)
         lpath = Path(args.local_path)
         metadata = _get_metadata_path(args, ipath, lpath, "download")

--- a/ibridges/cli/data_operations.py
+++ b/ibridges/cli/data_operations.py
@@ -164,7 +164,7 @@ class CliDownload(BaseCliCommand):
     @staticmethod
     def run_shell(session, parser, args):
         """Download the data object or collection."""
-        if args.on_error.lower() not in ["fail", "warn", "skip"]:
+        if args.on_error and args.on_error.lower() not in ["fail", "warn", "skip"]:
             parser.error(
                 f"'on-error': Unknown keyword {args.on_error}, choose 'fail', 'warn' or 'skip'")
         ipath = parse_remote(args.remote_path, session)
@@ -248,7 +248,7 @@ class CliUpload(BaseCliCommand):
     @staticmethod
     def run_shell(session, parser, args):
         """Upload a data object or collection to the iRODS server."""
-        if args.on_error.lower() not in ["fail", "warn", "skip"]:
+        if args.on_error and args.on_error.lower() not in ["fail", "warn", "skip"]:
             parser.error(
                 f"'on-error': Unknown keyword {args.on_error}, choose 'fail', 'warn' or 'skip'")
         lpath = args.local_path
@@ -323,7 +323,7 @@ class CliSync(BaseCliCommand):
     @staticmethod
     def run_shell(session, parser, args):
         """Synchronize a directory and collection."""
-        if args.on_error.lower() not in ["fail", "warn", "skip"]:
+        if args.on_error and args.on_error.lower() not in ["fail", "warn", "skip"]:
             parser.error(
                 f"'on-error': Unknown keyword {args.on_error}, choose 'fail', 'warn' or 'skip'")
         src_path = _parse_str(args.source, session)

--- a/ibridges/cli/data_operations.py
+++ b/ibridges/cli/data_operations.py
@@ -1,4 +1,5 @@
 """Subcommands that do data operations."""
+
 import argparse
 from pathlib import Path
 from typing import Literal, Union
@@ -40,6 +41,7 @@ class CliMakeCollection(BaseCliCommand):
             parser.error(f"Cannot create collection {ipath}: already exists.")
         ipath.create_collection(session, ipath)
 
+
 class CliRm(BaseCliCommand):
     """Subcommand for removing a data object or collection."""
 
@@ -56,9 +58,10 @@ class CliRm(BaseCliCommand):
             type=str,
         )
         parser.add_argument(
-            "-r", "--recursive",
+            "-r",
+            "--recursive",
             help="Remove collections and their content recursively.",
-            action="store_true"
+            action="store_true",
         )
         return parser
 
@@ -72,11 +75,14 @@ class CliRm(BaseCliCommand):
             if args.recursive:
                 ipath.remove()
             else:
-                parser.error(f"Cannot remove {ipath}: is a collection. "
-                             "Use -r to remove collections.")
+                parser.error(
+                    f"Cannot remove {ipath}: is a collection. " "Use -r to remove collections."
+                )
 
-def _get_metadata_path(args, ipath: IrodsPath, lpath: Union[str, Path],
-                       mode: str) -> Union[None, str, Path]:
+
+def _get_metadata_path(
+    args, ipath: IrodsPath, lpath: Union[str, Path], mode: str
+) -> Union[None, str, Path]:
     metadata: Union[Literal[False], Path, None]
     metadata = False if not hasattr(args, "metadata") else args.metadata
     if ipath.dataobject_exists() and metadata is None:
@@ -92,6 +98,7 @@ def _get_metadata_path(args, ipath: IrodsPath, lpath: Union[str, Path],
     if metadata is False:
         return None
     return metadata
+
 
 class CliDownload(BaseCliCommand):
     """Subcommand for downloading a data object or collection."""
@@ -141,9 +148,12 @@ class CliDownload(BaseCliCommand):
         )
         parser.add_argument(
             "--on-error",
-            help="'fail' (default): stop on error; 'warn': warn and continue; 'skip': continue",
+            help="When a transfer of a file fails, by default the whole transfer will stop and "
+                 "print the error message(fail). By setting 'on-error' to 'warn', those errors "
+                 "will be turned into warnings and the transfer continues with the next file. "
+                 "Setting 'on-error' to 'skip' will omit any message and simply proceed.",
             default="fail",
-            type=str
+            type=str,
         )
         return parser
 
@@ -161,7 +171,7 @@ class CliDownload(BaseCliCommand):
                 overwrite=args.overwrite,
                 resc_name=args.resource,
                 dry_run=args.dry_run,
-                on_err = args.on_error,
+                on_error=args.on_error,
                 metadata=metadata,
             )
         except (DoesNotExistError, PermissionError, NotADirectoryError, FileExistsError) as exc:
@@ -176,8 +186,11 @@ class CliUpload(BaseCliCommand):
     autocomplete = ["local_path", "remote_coll"]
     names = ["upload"]
     description = "Upload a data object or collection from an iRODS server."
-    examples = ["local_file.txt", "local_file.txt irods:remote_collection",
-                "local_dir irods:remote_collection"]
+    examples = [
+        "local_file.txt",
+        "local_file.txt irods:remote_collection",
+        "local_dir irods:remote_collection",
+    ]
 
     @classmethod
     def _mod_parser(cls, parser):
@@ -191,7 +204,7 @@ class CliUpload(BaseCliCommand):
             help="Path to remote iRODS location starting with 'irods:'",
             type=str,
             default=".",
-            nargs="?"
+            nargs="?",
         )
         parser.add_argument(
             "--overwrite",
@@ -219,9 +232,12 @@ class CliUpload(BaseCliCommand):
         )
         parser.add_argument(
             "--on-error",
-            help="'fail' (default): stop on error; 'warn': warn and continue; 'skip': continue",
+            help="When a transfer of a file fails, by default the whole transfer will stop and "
+                 "print the error message(fail). By setting 'on-error' to 'warn', those errors "
+                 "will be turned into warnings and the transfer continues with the next file. "
+                 "Setting 'on-error' to 'skip' will omit any message and simply proceed.",
             default="fail",
-            type=str
+            type=str,
         )
         return parser
 
@@ -240,7 +256,7 @@ class CliUpload(BaseCliCommand):
                 resc_name=args.resource,
                 dry_run=args.dry_run,
                 metadata=metadata,
-                on_err=args.on_error,
+                on_error=args.on_error,
             )
         except (FileNotFoundError, PermissionError, DataObjectExistsError) as exc:
             parser.error(exc)
@@ -263,7 +279,6 @@ class CliSync(BaseCliCommand):
     names = ["sync"]
     description = "Synchronize files/directories between local and remote."
     examples = ["local_dir irods:remote_collection", "irods:remote_collection local_dir"]
-
 
     @classmethod
     def _mod_parser(cls, parser):
@@ -294,7 +309,7 @@ class CliSync(BaseCliCommand):
             "--on-error",
             help="'fail' (default): stop on error; 'warn': warn and continue; 'skip': continue",
             default="fail",
-            type=str
+            type=str,
         )
         return parser
 
@@ -308,8 +323,10 @@ class CliSync(BaseCliCommand):
         elif isinstance(src_path, IrodsPath) and isinstance(dest_path, Path):
             metadata = _get_metadata_path(args, src_path, dest_path, "sync")
         else:
-            parser.error("Please provide as the source and destination exactly one local path,"
-                         " and one remote path.")
+            parser.error(
+                "Please provide as the source and destination exactly one local path,"
+                " and one remote path."
+            )
             return
         try:
             ops = sync(
@@ -318,7 +335,7 @@ class CliSync(BaseCliCommand):
                 dest_path,
                 dry_run=args.dry_run,
                 metadata=metadata,
-                on_err=args.on_error
+                on_error=args.on_error,
             )
         except (CollectionDoesNotExistError, NotACollectionError, NotADirectoryError) as exc:
             parser.error(exc)

--- a/ibridges/cli/data_operations.py
+++ b/ibridges/cli/data_operations.py
@@ -15,6 +15,14 @@ from ibridges.exception import (
 )
 from ibridges.path import IrodsPath
 
+ON_ERROR_HELP = (
+    "When a transfer of a file fails, by default the whole transfer will stop and print the error "
+    "message(fail). By setting 'on-error' to 'warn', those errors will be turned into warnings and "
+    "the transfer continues with the next file. "
+    "Setting 'on-error' to 'skip' will omit any message and simply proceed."
+)
+
+
 
 class CliMakeCollection(BaseCliCommand):
     """Subcommand for creating a new collection."""
@@ -148,11 +156,7 @@ class CliDownload(BaseCliCommand):
         )
         parser.add_argument(
             "--on-error",
-            help="When a transfer of a file fails, by default the whole transfer will stop and "
-                 "print the error message(fail). By setting 'on-error' to 'warn', those errors "
-                 "will be turned into warnings and the transfer continues with the next file. "
-                 "Setting 'on-error' to 'skip' will omit any message and simply proceed.",
-            default="fail",
+            help=ON_ERROR_HELP,
             type=str,
         )
         return parser
@@ -160,7 +164,7 @@ class CliDownload(BaseCliCommand):
     @staticmethod
     def run_shell(session, parser, args):
         """Download the data object or collection."""
-        if args.on_error not in ["fail", "warn", "skip"]:
+        if args.on_error.lower() not in ["fail", "warn", "skip"]:
             parser.error(
                 f"'on-error': Unknown keyword {args.on_error}, choose 'fail', 'warn' or 'skip'")
         ipath = parse_remote(args.remote_path, session)
@@ -235,10 +239,7 @@ class CliUpload(BaseCliCommand):
         )
         parser.add_argument(
             "--on-error",
-            help="When a transfer of a file fails, by default the whole transfer will stop and "
-                 "print the error message(fail). By setting 'on-error' to 'warn', those errors "
-                 "will be turned into warnings and the transfer continues with the next file. "
-                 "Setting 'on-error' to 'skip' will omit any message and simply proceed.",
+            help=ON_ERROR_HELP,
             default="fail",
             type=str,
         )
@@ -247,7 +248,7 @@ class CliUpload(BaseCliCommand):
     @staticmethod
     def run_shell(session, parser, args):
         """Upload a data object or collection to the iRODS server."""
-        if args.on_error not in ["fail", "warn", "skip"]:
+        if args.on_error.lower() not in ["fail", "warn", "skip"]:
             parser.error(
                 f"'on-error': Unknown keyword {args.on_error}, choose 'fail', 'warn' or 'skip'")
         lpath = args.local_path
@@ -313,7 +314,7 @@ class CliSync(BaseCliCommand):
         )
         parser.add_argument(
             "--on-error",
-            help="'fail' (default): stop on error; 'warn': warn and continue; 'skip': continue",
+            help=ON_ERROR_HELP,
             default="fail",
             type=str,
         )
@@ -322,7 +323,7 @@ class CliSync(BaseCliCommand):
     @staticmethod
     def run_shell(session, parser, args):
         """Synchronize a directory and collection."""
-        if args.on_error not in ["fail", "warn", "skip"]:
+        if args.on_error.lower() not in ["fail", "warn", "skip"]:
             parser.error(
                 f"'on-error': Unknown keyword {args.on_error}, choose 'fail', 'warn' or 'skip'")
         src_path = _parse_str(args.source, session)

--- a/ibridges/cli/data_operations.py
+++ b/ibridges/cli/data_operations.py
@@ -249,7 +249,7 @@ class CliUpload(BaseCliCommand):
         """Upload a data object or collection to the iRODS server."""
         if args.on_error not in ["fail", "warn", "skip"]:
             parser.error(
-                f"'on-error': Unknonw keyword {args.on_error}, choose 'fail', 'warn' or 'skip'")
+                f"'on-error': Unknown keyword {args.on_error}, choose 'fail', 'warn' or 'skip'")
         lpath = args.local_path
         ipath = parse_remote(args.remote_path, session)
         metadata = _get_metadata_path(args, ipath, lpath, "upload")

--- a/ibridges/cli/data_operations.py
+++ b/ibridges/cli/data_operations.py
@@ -140,9 +140,10 @@ class CliDownload(BaseCliCommand):
             nargs="?",
         )
         parser.add_argument(
-            "--ignore_err",
-            help="Turn errors into warning and continue download.",
-            action="store_true",
+            "--on-error",
+            help="'fail' (default): stop on error; 'warn': warn and continue; 'skip': continue",
+            default="fail",
+            type=str
         )
         return parser
 
@@ -160,8 +161,8 @@ class CliDownload(BaseCliCommand):
                 overwrite=args.overwrite,
                 resc_name=args.resource,
                 dry_run=args.dry_run,
+                on_err = args.on_error,
                 metadata=metadata,
-                ignore_err= args.ignore_err,
             )
         except (DoesNotExistError, PermissionError, NotADirectoryError, FileExistsError) as exc:
             parser.error(str(exc))
@@ -217,9 +218,10 @@ class CliUpload(BaseCliCommand):
             nargs="?",
         )
         parser.add_argument(
-            "--ignore_err",
-            help="Turn errors into warning and continue download.",
-            action="store_true",
+            "--on-error",
+            help="'fail' (default): stop on error; 'warn': warn and continue; 'skip': continue",
+            default="fail",
+            type=str
         )
         return parser
 
@@ -238,7 +240,7 @@ class CliUpload(BaseCliCommand):
                 resc_name=args.resource,
                 dry_run=args.dry_run,
                 metadata=metadata,
-                ignore_err=args.ignore_err,
+                on_err=args.on_error,
             )
         except (FileNotFoundError, PermissionError, DataObjectExistsError) as exc:
             parser.error(exc)
@@ -289,9 +291,10 @@ class CliSync(BaseCliCommand):
             nargs="?",
         )
         parser.add_argument(
-            "--ignore_err",
-            help="Turn errors into warning and continue download.",
-            action="store_true",
+            "--on-error",
+            help="'fail' (default): stop on error; 'warn': warn and continue; 'skip': continue",
+            default="fail",
+            type=str
         )
         return parser
 
@@ -315,7 +318,7 @@ class CliSync(BaseCliCommand):
                 dest_path,
                 dry_run=args.dry_run,
                 metadata=metadata,
-                ignore_err=args.ignore_err
+                on_err=args.on_error
             )
         except (CollectionDoesNotExistError, NotACollectionError, NotADirectoryError) as exc:
             parser.error(exc)

--- a/ibridges/cli/data_operations.py
+++ b/ibridges/cli/data_operations.py
@@ -139,6 +139,11 @@ class CliDownload(BaseCliCommand):
             type=Path,
             nargs="?",
         )
+        parser.add_argument(
+            "--ignore_err",
+            help="Turn errors into warning and continue download.",
+            action="store_true",
+        )
         return parser
 
     @staticmethod
@@ -156,6 +161,7 @@ class CliDownload(BaseCliCommand):
                 resc_name=args.resource,
                 dry_run=args.dry_run,
                 metadata=metadata,
+                ignore_err= args.ignore_err,
             )
         except (DoesNotExistError, PermissionError, NotADirectoryError, FileExistsError) as exc:
             parser.error(str(exc))
@@ -210,6 +216,11 @@ class CliUpload(BaseCliCommand):
             type=Path,
             nargs="?",
         )
+        parser.add_argument(
+            "--ignore_err",
+            help="Turn errors into warning and continue download.",
+            action="store_true",
+        )
         return parser
 
     @staticmethod
@@ -227,6 +238,7 @@ class CliUpload(BaseCliCommand):
                 resc_name=args.resource,
                 dry_run=args.dry_run,
                 metadata=metadata,
+                ignore_err=args.ignore_err,
             )
         except (FileNotFoundError, PermissionError, DataObjectExistsError) as exc:
             parser.error(exc)
@@ -276,6 +288,11 @@ class CliSync(BaseCliCommand):
             type=Path,
             nargs="?",
         )
+        parser.add_argument(
+            "--ignore_err",
+            help="Turn errors into warning and continue download.",
+            action="store_true",
+        )
         return parser
 
     @staticmethod
@@ -298,6 +315,7 @@ class CliSync(BaseCliCommand):
                 dest_path,
                 dry_run=args.dry_run,
                 metadata=metadata,
+                ignore_err=args.ignore_err
             )
         except (CollectionDoesNotExistError, NotACollectionError, NotADirectoryError) as exc:
             parser.error(exc)

--- a/ibridges/cli/data_operations.py
+++ b/ibridges/cli/data_operations.py
@@ -324,7 +324,7 @@ class CliSync(BaseCliCommand):
         """Synchronize a directory and collection."""
         if args.on_error not in ["fail", "warn", "skip"]:
             parser.error(
-                f"'on-error': Unknonw keyword {args.on_error}, choose 'fail', 'warn' or 'skip'")
+                f"'on-error': Unknown keyword {args.on_error}, choose 'fail', 'warn' or 'skip'")
         src_path = _parse_str(args.source, session)
         dest_path = _parse_str(args.destination, session)
         if isinstance(src_path, Path) and isinstance(dest_path, IrodsPath):

--- a/ibridges/cli/data_operations.py
+++ b/ibridges/cli/data_operations.py
@@ -249,7 +249,7 @@ class CliUpload(BaseCliCommand):
         """Upload a data object or collection to the iRODS server."""
         if args.on_error not in ["fail", "warn", "skip"]:
             parser.error(
-                f"'on-error': Unknonw keyword {args.on_error}, choose 'fail', 'warn' or 'skip'") 
+                f"'on-error': Unknonw keyword {args.on_error}, choose 'fail', 'warn' or 'skip'")
         lpath = args.local_path
         ipath = parse_remote(args.remote_path, session)
         metadata = _get_metadata_path(args, ipath, lpath, "upload")

--- a/ibridges/cli/data_operations.py
+++ b/ibridges/cli/data_operations.py
@@ -160,6 +160,9 @@ class CliDownload(BaseCliCommand):
     @staticmethod
     def run_shell(session, parser, args):
         """Download the data object or collection."""
+        if args.on_error not in ["fail", "warn", "skip"]:
+            parser.error(
+                f"'on-error': Unknonw keyword {args.on_error}, choose 'fail', 'warn' or 'skip'")
         ipath = parse_remote(args.remote_path, session)
         lpath = Path(args.local_path)
         metadata = _get_metadata_path(args, ipath, lpath, "download")
@@ -244,6 +247,9 @@ class CliUpload(BaseCliCommand):
     @staticmethod
     def run_shell(session, parser, args):
         """Upload a data object or collection to the iRODS server."""
+        if args.on_error not in ["fail", "warn", "skip"]:
+            parser.error(
+                f"'on-error': Unknonw keyword {args.on_error}, choose 'fail', 'warn' or 'skip'") 
         lpath = args.local_path
         ipath = parse_remote(args.remote_path, session)
         metadata = _get_metadata_path(args, ipath, lpath, "upload")
@@ -316,6 +322,9 @@ class CliSync(BaseCliCommand):
     @staticmethod
     def run_shell(session, parser, args):
         """Synchronize a directory and collection."""
+        if args.on_error not in ["fail", "warn", "skip"]:
+            parser.error(
+                f"'on-error': Unknonw keyword {args.on_error}, choose 'fail', 'warn' or 'skip'")
         src_path = _parse_str(args.source, session)
         dest_path = _parse_str(args.destination, session)
         if isinstance(src_path, Path) and isinstance(dest_path, IrodsPath):

--- a/ibridges/cli/data_operations.py
+++ b/ibridges/cli/data_operations.py
@@ -76,7 +76,7 @@ class CliRm(BaseCliCommand):
                 ipath.remove()
             else:
                 parser.error(
-                    f"Cannot remove {ipath}: is a collection. " "Use -r to remove collections."
+                    f"Cannot remove {ipath}: is a collection. Use -r to remove collections."
                 )
 
 

--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -104,10 +104,6 @@ def upload(
     """
     local_path = Path(local_path)
     ipath = IrodsPath(session, irods_path)
-    
-    if on_err.lower() not in ["fail", "warn", "skip"]:
-        on_err = "fail"
-        warnings.warn(f"on_err = {on_err} not regognised; set to 'fail'.") 
 
     ops = Operations()
     if local_path.is_dir():
@@ -217,10 +213,6 @@ def download(
     >>> ops.execute()
 
     """
-    if on_err.lower() not in ["fail", "warn", "skip"]:
-        on_err = "fail"
-        warnings.warn(f"on_err = {on_err} not regognised; set to 'fail'.")
-
     irods_path = IrodsPath(session, irods_path)
     local_path = Path(local_path)
 
@@ -372,10 +364,6 @@ def sync(
 
     """
     _param_checks(source, target)
-
-    if on_err.lower() not in ["fail", "warn", "skip"]:
-        on_err = "fail"
-        warnings.warn(f"on_err = {on_err} not regognised; set to 'fail'.")
 
     if isinstance(source, IrodsPath):
         if not source.collection_exists():
@@ -539,7 +527,7 @@ def _transfer_needed(source: Union[IrodsPath, Path],
             if isinstance(dest, IrodsPath):
                 raise DataObjectExistsError(err_msg)
             raise FileExistsError(err_msg)
-        elif on_err == "warn":
+        if on_err == "warn":
             warnings.warn(f"Skipping file/data object {source} -> {dest} since "
                           f"both exist and overwrite == False.")
         return False

--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -35,7 +35,7 @@ def upload(
     local_path: Union[str, Path],
     irods_path: Union[str, IrodsPath],
     overwrite: bool = False,
-    ignore_err: bool = False,
+    on_err: str = "fail",
     resc_name: str = "",
     copy_empty_folders: bool = True,
     options: Optional[dict] = None,
@@ -55,10 +55,10 @@ def upload(
         Absolute irods destination path
     overwrite:
         If data object or collection already exists on iRODS, overwrite
-    ignore_err:
-        If an error occurs during upload, and ignore_err is set to True, any errors encountered
-        will be transformed into warnings and iBridges will continue to upload the remaining files.
-        By default all errors will stop the process of uploading.
+    on_err:
+        'fail': Stop transfer and throw exception
+        'warn': Show a warning but continue
+        'skip': Continue without any notification
     resc_name:
         Name of the resource to which data is uploaded, by default the server will decide
     copy_empty_folders:
@@ -104,6 +104,11 @@ def upload(
     """
     local_path = Path(local_path)
     ipath = IrodsPath(session, irods_path)
+    
+    if on_err.lower() not in ["fail", "warn", "skip"]:
+        on_err = "fail"
+        warnings.warn(f"on_err = {on_err} not regognised; set to 'fail'.") 
+
     ops = Operations()
     if local_path.is_dir():
         idest_path = ipath / local_path.name
@@ -111,7 +116,7 @@ def upload(
             raise DataObjectExistsError(f"Data object {idest_path} already exists.")
         ops = _up_sync_operations(
             local_path, idest_path, copy_empty_folders=copy_empty_folders, depth=None,
-            overwrite=overwrite, ignore_err=ignore_err
+            overwrite=overwrite, on_err=on_err
         )
         if not idest_path.collection_exists():
             ops.add_create_coll(idest_path)
@@ -120,7 +125,7 @@ def upload(
     elif local_path.is_file():
         idest_path = ipath / local_path.name if ipath.collection_exists() else ipath
         obj_exists = idest_path.dataobject_exists()
-        if not obj_exists or _transfer_needed(local_path, idest_path, overwrite, ignore_err):
+        if not obj_exists or _transfer_needed(local_path, idest_path, overwrite, on_err):
             ops.add_upload(local_path, idest_path)
 
     elif local_path.is_symlink():
@@ -134,7 +139,7 @@ def upload(
     if metadata is not None:
         ops.add_meta_upload(idest_path, metadata)
     if not dry_run:
-        ops.execute(session, ignore_err=ignore_err, progress_bar=progress_bar)
+        ops.execute(session, on_err=on_err, progress_bar=progress_bar)
     return ops
 
 
@@ -143,7 +148,7 @@ def download(
     irods_path: Union[str, IrodsPath],
     local_path: Union[str, Path],
     overwrite: bool = False,
-    ignore_err: bool = False,
+    on_err: str = "fail",
     resc_name: str = "",
     copy_empty_folders: bool = True,
     options: Optional[dict] = None,
@@ -162,12 +167,11 @@ def download(
     local_path:
         Absolute path to the destination directory
     overwrite:
-        If an error occurs during download, and ignore_err is set to True, any errors encountered
-        will be transformed into warnings and iBridges will continue to download the remaining
-        files.
-        By default all errors will stop the process of downloading.
-    ignore_err:
-        Collections: If download of an item fails print error and continue with next item.
+        If data object or collection already exists on iRODS, overwrite.
+    on_err:
+        'fail': Stop transfer and throw exception
+        'warn': Show a warning but continue
+        'skip': Continue without any notification
     resc_name:
         Name of the resource from which data is downloaded, by default the server will decide.
     copy_empty_folders:
@@ -213,6 +217,10 @@ def download(
     >>> ops.execute()
 
     """
+    if on_err.lower() not in ["fail", "warn", "skip"]:
+        on_err = "fail"
+        warnings.warn(f"on_err = {on_err} not regognised; set to 'fail'.")
+
     irods_path = IrodsPath(session, irods_path)
     local_path = Path(local_path)
 
@@ -226,7 +234,7 @@ def download(
         ops = _down_sync_operations(
             irods_path, local_path / irods_path.name, metadata=metadata,
             copy_empty_folders=copy_empty_folders, overwrite=overwrite,
-            ignore_err=ignore_err
+            on_err=on_err
         )
         if not local_path.is_dir():
             ops.add_create_dir(Path(local_path))
@@ -236,7 +244,7 @@ def download(
         if local_path.is_dir():
             local_path = local_path / irods_path.name
         if not local_path.is_file() or _transfer_needed(
-                irods_path, local_path, overwrite, ignore_err):
+                irods_path, local_path, overwrite, on_err):
             ops.add_download(irods_path, local_path)
         if metadata is not None:
             ops.add_meta_download(irods_path, irods_path, metadata)
@@ -247,7 +255,7 @@ def download(
     ops.resc_name = resc_name
     ops.options = options
     if not dry_run:
-        ops.execute(session, ignore_err=ignore_err, progress_bar=progress_bar)
+        ops.execute(session, on_err=on_err, progress_bar=progress_bar)
     return ops
 
 
@@ -285,7 +293,7 @@ def sync(
     target: Union[str, Path, IrodsPath],
     max_level: Optional[int] = None,
     dry_run: bool = False,
-    ignore_err: bool = False,
+    on_err: str = "fail",
     copy_empty_folders: bool = False,
     resc_name: str = "",
     options: Optional[dict] = None,
@@ -323,6 +331,10 @@ def sync(
         If an error occurs during the transfer, and ignore_err is set to True,
         any errors encountered will be transformed into warnings and iBridges will continue
         to transfer the remaining files.
+    on_err:
+        'fail': Stop transfer and throw exception
+        'warn': Show a warning but continue
+        'skip': Continue without any notification
     copy_empty_folders:
         Controls whether folders/collections that contain no files or subfolders/subcollections
         will be synchronized.
@@ -361,6 +373,10 @@ def sync(
     """
     _param_checks(source, target)
 
+    if on_err.lower() not in ["fail", "warn", "skip"]:
+        on_err = "fail"
+        warnings.warn(f"on_err = {on_err} not regognised; set to 'fail'.")
+
     if isinstance(source, IrodsPath):
         if not source.collection_exists():
             if source.dataobject_exists():
@@ -388,7 +404,7 @@ def sync(
     ops.resc_name = resc_name
     ops.options = options
     if not dry_run:
-        ops.execute(session, ignore_err=ignore_err, progress_bar=progress_bar)
+        ops.execute(session, on_err=on_err, progress_bar=progress_bar)
 
     return ops
 
@@ -503,7 +519,7 @@ def _param_checks(source, target):
 
 def _transfer_needed(source: Union[IrodsPath, Path],
                      dest: Union[IrodsPath, Path],
-                     overwrite: bool, ignore_err: bool):
+                     overwrite: bool, on_err: str):
     if isinstance(source, IrodsPath):
         # Ensure that if the source is remote, the dest should be local.
         if not isinstance(dest, Path):
@@ -517,14 +533,15 @@ def _transfer_needed(source: Union[IrodsPath, Path],
         lpath = source
 
     if not overwrite:
-        if not ignore_err:
+        if on_err == "fail":
             err_msg = (f"Cannot overwrite {source} -> {dest} unless overwrite==True. "
-                       f"To ignore this error and skip the files use ignore_err==True.")
+                       f"To ignore this error and skip the files use on_err=='warn'.")
             if isinstance(dest, IrodsPath):
                 raise DataObjectExistsError(err_msg)
             raise FileExistsError(err_msg)
-        warnings.warn(f"Skipping file/data object {source} -> {dest} since "
-                      f"both exist and overwrite == False.")
+        elif on_err == "warn":
+            warnings.warn(f"Skipping file/data object {source} -> {dest} since "
+                          f"both exist and overwrite == False.")
         return False
     if checksums_equal(ipath, lpath):
         return False
@@ -533,7 +550,7 @@ def _transfer_needed(source: Union[IrodsPath, Path],
 
 def _down_sync_operations(isource_path: IrodsPath, ldest_path: Path,
                           overwrite: bool,
-                          ignore_err: bool = False,
+                          on_err: str = "fail",
                           copy_empty_folders: bool  =True, depth: Optional[int] = None,
                           metadata: Union[None, str, Path] = None) -> Operations:
     operations = Operations()
@@ -543,7 +560,7 @@ def _down_sync_operations(isource_path: IrodsPath, ldest_path: Path,
         lpath = ldest_path.joinpath(*ipath.relative_to(isource_path).parts)
         if ipath.dataobject_exists():
             if lpath.is_file():
-                if _transfer_needed(ipath, lpath, overwrite, ignore_err):
+                if _transfer_needed(ipath, lpath, overwrite, on_err):
                     operations.add_download(ipath, lpath)
             else:
                 operations.add_download(ipath, lpath)
@@ -558,7 +575,7 @@ def _down_sync_operations(isource_path: IrodsPath, ldest_path: Path,
 def _up_sync_operations(lsource_path: Path, idest_path: IrodsPath,  # pylint: disable=too-many-branches
                         overwrite: bool,
                         copy_empty_folders: bool = True, depth: Optional[int] = None,
-                        ignore_err: bool = False) -> Operations:
+                        on_err: str = "fail") -> Operations:
     operations = Operations()
     session = idest_path.session
     try:
@@ -580,7 +597,7 @@ def _up_sync_operations(lsource_path: Path, idest_path: IrodsPath,  # pylint: di
                 continue
             if str(ipath) in remote_ipaths:
                 ipath = remote_ipaths[str(ipath)]
-                if _transfer_needed(lpath, ipath, overwrite, ignore_err):
+                if _transfer_needed(lpath, ipath, overwrite, on_err):
                     operations.add_upload(lpath, ipath)
             else:
                 ipath = CachedIrodsPath(session, None, False, None, str(ipath))

--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -35,7 +35,7 @@ def upload(
     local_path: Union[str, Path],
     irods_path: Union[str, IrodsPath],
     overwrite: bool = False,
-    on_err: str = "fail",
+    on_error: str = "fail",
     resc_name: str = "",
     copy_empty_folders: bool = True,
     options: Optional[dict] = None,
@@ -55,10 +55,11 @@ def upload(
         Absolute irods destination path
     overwrite:
         If data object or collection already exists on iRODS, overwrite
-    on_err:
-        'fail': Stop transfer and throw exception
-        'warn': Show a warning but continue
-        'skip': Continue without any notification
+    on_error:
+        When a transfer of a file fails, by default the whole transfer will stop and
+        print the error message(fail). By setting 'on-error' to 'warn', those errors
+        will be turned into warnings and the transfer continues with the next file.
+        Setting 'on-error' to 'skip' will omit any message and simply proceed.
     resc_name:
         Name of the resource to which data is uploaded, by default the server will decide
     copy_empty_folders:
@@ -112,7 +113,7 @@ def upload(
             raise DataObjectExistsError(f"Data object {idest_path} already exists.")
         ops = _up_sync_operations(
             local_path, idest_path, copy_empty_folders=copy_empty_folders, depth=None,
-            overwrite=overwrite, on_err=on_err
+            overwrite=overwrite, on_error=on_error
         )
         if not idest_path.collection_exists():
             ops.add_create_coll(idest_path)
@@ -121,7 +122,7 @@ def upload(
     elif local_path.is_file():
         idest_path = ipath / local_path.name if ipath.collection_exists() else ipath
         obj_exists = idest_path.dataobject_exists()
-        if not obj_exists or _transfer_needed(local_path, idest_path, overwrite, on_err):
+        if not obj_exists or _transfer_needed(local_path, idest_path, overwrite, on_error):
             ops.add_upload(local_path, idest_path)
 
     elif local_path.is_symlink():
@@ -135,7 +136,7 @@ def upload(
     if metadata is not None:
         ops.add_meta_upload(idest_path, metadata)
     if not dry_run:
-        ops.execute(session, on_err=on_err, progress_bar=progress_bar)
+        ops.execute(session, on_error=on_error, progress_bar=progress_bar)
     return ops
 
 
@@ -144,7 +145,7 @@ def download(
     irods_path: Union[str, IrodsPath],
     local_path: Union[str, Path],
     overwrite: bool = False,
-    on_err: str = "fail",
+    on_error: str = "fail",
     resc_name: str = "",
     copy_empty_folders: bool = True,
     options: Optional[dict] = None,
@@ -164,10 +165,11 @@ def download(
         Absolute path to the destination directory
     overwrite:
         If data object or collection already exists on iRODS, overwrite.
-    on_err:
-        'fail': Stop transfer and throw exception
-        'warn': Show a warning but continue
-        'skip': Continue without any notification
+    on_error:
+        When a transfer of a file fails, by default the whole transfer will stop and
+        print the error message(fail). By setting 'on-error' to 'warn', those errors
+        will be turned into warnings and the transfer continues with the next file.
+        Setting 'on-error' to 'skip' will omit any message and simply proceed.
     resc_name:
         Name of the resource from which data is downloaded, by default the server will decide.
     copy_empty_folders:
@@ -226,7 +228,7 @@ def download(
         ops = _down_sync_operations(
             irods_path, local_path / irods_path.name, metadata=metadata,
             copy_empty_folders=copy_empty_folders, overwrite=overwrite,
-            on_err=on_err
+            on_error=on_error
         )
         if not local_path.is_dir():
             ops.add_create_dir(Path(local_path))
@@ -236,7 +238,7 @@ def download(
         if local_path.is_dir():
             local_path = local_path / irods_path.name
         if not local_path.is_file() or _transfer_needed(
-                irods_path, local_path, overwrite, on_err):
+                irods_path, local_path, overwrite, on_error):
             ops.add_download(irods_path, local_path)
         if metadata is not None:
             ops.add_meta_download(irods_path, irods_path, metadata)
@@ -247,7 +249,7 @@ def download(
     ops.resc_name = resc_name
     ops.options = options
     if not dry_run:
-        ops.execute(session, on_err=on_err, progress_bar=progress_bar)
+        ops.execute(session, on_error=on_error, progress_bar=progress_bar)
     return ops
 
 
@@ -285,7 +287,7 @@ def sync(
     target: Union[str, Path, IrodsPath],
     max_level: Optional[int] = None,
     dry_run: bool = False,
-    on_err: str = "fail",
+    on_error: str = "fail",
     copy_empty_folders: bool = False,
     resc_name: str = "",
     options: Optional[dict] = None,
@@ -323,10 +325,11 @@ def sync(
         If an error occurs during the transfer, and ignore_err is set to True,
         any errors encountered will be transformed into warnings and iBridges will continue
         to transfer the remaining files.
-    on_err:
-        'fail': Stop transfer and throw exception
-        'warn': Show a warning but continue
-        'skip': Continue without any notification
+    on_error:
+        When a transfer of a file fails, by default the whole transfer will stop and
+        print the error message(fail). By setting 'on-error' to 'warn', those errors
+        will be turned into warnings and the transfer continues with the next file.
+        Setting 'on-error' to 'skip' will omit any message and simply proceed.
     copy_empty_folders:
         Controls whether folders/collections that contain no files or subfolders/subcollections
         will be synchronized.
@@ -392,7 +395,7 @@ def sync(
     ops.resc_name = resc_name
     ops.options = options
     if not dry_run:
-        ops.execute(session, on_err=on_err, progress_bar=progress_bar)
+        ops.execute(session, on_error=on_error, progress_bar=progress_bar)
 
     return ops
 
@@ -507,7 +510,7 @@ def _param_checks(source, target):
 
 def _transfer_needed(source: Union[IrodsPath, Path],
                      dest: Union[IrodsPath, Path],
-                     overwrite: bool, on_err: str):
+                     overwrite: bool, on_error: str):
     if isinstance(source, IrodsPath):
         # Ensure that if the source is remote, the dest should be local.
         if not isinstance(dest, Path):
@@ -521,13 +524,13 @@ def _transfer_needed(source: Union[IrodsPath, Path],
         lpath = source
 
     if not overwrite:
-        if on_err == "fail":
+        if on_error == "fail":
             err_msg = (f"Cannot overwrite {source} -> {dest} unless overwrite==True. "
-                       f"To ignore this error and skip the files use on_err=='warn'.")
+                       f"To ignore this error and skip the files use on_error=='warn'.")
             if isinstance(dest, IrodsPath):
                 raise DataObjectExistsError(err_msg)
             raise FileExistsError(err_msg)
-        if on_err == "warn":
+        if on_error == "warn":
             warnings.warn(f"Skipping file/data object {source} -> {dest} since "
                           f"both exist and overwrite == False.")
         return False
@@ -538,7 +541,7 @@ def _transfer_needed(source: Union[IrodsPath, Path],
 
 def _down_sync_operations(isource_path: IrodsPath, ldest_path: Path,
                           overwrite: bool,
-                          on_err: str = "fail",
+                          on_error: str = "fail",
                           copy_empty_folders: bool  =True, depth: Optional[int] = None,
                           metadata: Union[None, str, Path] = None) -> Operations:
     operations = Operations()
@@ -548,7 +551,7 @@ def _down_sync_operations(isource_path: IrodsPath, ldest_path: Path,
         lpath = ldest_path.joinpath(*ipath.relative_to(isource_path).parts)
         if ipath.dataobject_exists():
             if lpath.is_file():
-                if _transfer_needed(ipath, lpath, overwrite, on_err):
+                if _transfer_needed(ipath, lpath, overwrite, on_error):
                     operations.add_download(ipath, lpath)
             else:
                 operations.add_download(ipath, lpath)
@@ -563,7 +566,7 @@ def _down_sync_operations(isource_path: IrodsPath, ldest_path: Path,
 def _up_sync_operations(lsource_path: Path, idest_path: IrodsPath,  # pylint: disable=too-many-branches
                         overwrite: bool,
                         copy_empty_folders: bool = True, depth: Optional[int] = None,
-                        on_err: str = "fail") -> Operations:
+                        on_error: str = "fail") -> Operations:
     operations = Operations()
     session = idest_path.session
     try:
@@ -585,7 +588,7 @@ def _up_sync_operations(lsource_path: Path, idest_path: IrodsPath,  # pylint: di
                 continue
             if str(ipath) in remote_ipaths:
                 ipath = remote_ipaths[str(ipath)]
-                if _transfer_needed(lpath, ipath, overwrite, on_err):
+                if _transfer_needed(lpath, ipath, overwrite, on_error):
                     operations.add_upload(lpath, ipath)
             else:
                 ipath = CachedIrodsPath(session, None, False, None, str(ipath))

--- a/ibridges/exception.py
+++ b/ibridges/exception.py
@@ -16,3 +16,9 @@ class NotADataObjectError(DoesNotExistError):
 
 class DataObjectExistsError(DoesNotExistError):
     """When the data object already exists."""
+
+class ObjectTransferFailedError(Exception):
+    """When a data object could not be transferred to local."""
+
+class FileTransferFailedError(Exception):
+    """When a file could not be transferred to iRODS."""

--- a/ibridges/executor.py
+++ b/ibridges/executor.py
@@ -354,6 +354,7 @@ def _obj_put(  # pylint: disable=too-many-branches
     ignore_err: bool = False,
     pbar: Optional[tqdm_type] = None,
 ):
+    # pylint: disable=W0718,R0915,R0912
     """Upload `local_path` to `irods_path` following iRODS `options`.
 
     Parameters
@@ -433,7 +434,7 @@ def _obj_put(  # pylint: disable=too-many-branches
         except Exception as error:
             if not ignore_err:
                 msg = f"Cannot transfer {local_path} to {irods_path}, {repr(error)}"
-                raise FileTransferFailedError(msg)
+                raise FileTransferFailedError(msg) from error
             warnings.warn(msg)
     else:
         if not ignore_err:
@@ -457,6 +458,8 @@ def _obj_get(
     ignore_err: bool = False,
     pbar: Optional[tqdm_type] = None,
 ):
+    # pylint: disable=W0718,R0915,R0912
+
     """Download `irods_path` to `local_path` following iRODS `options`.
 
     Parameters
@@ -519,7 +522,7 @@ def _obj_get(
     except Exception as error:
         msg = f"Cannot transfer {irods_path} to {local_path}, {repr(error)}"
         if not ignore_err:
-            raise ObjectTransferFailedError
+            raise ObjectTransferFailedError from error
         warnings.warn(msg)
     if pbar is not None and not upd_put:
         pbar.update(IrodsPath(session, irods_path).size)

--- a/ibridges/executor.py
+++ b/ibridges/executor.py
@@ -392,7 +392,7 @@ def _obj_put(  # pylint: disable=too-many-branches
         Optional progress bar.
 
     """
-    if on_error.lower() not in ['fail', 'warn', 'skip']:
+    if on_error and on_error.lower() not in ['fail', 'warn', 'skip']:
         raise ValueError(f"'on_error' {on_error} not a valid value. Choose fail, warn or skip.")
 
     local_path = Path(local_path)
@@ -490,7 +490,7 @@ def _obj_get(
         Optional progress bar.
 
     """
-    if on_error.lower() not in ["fail", "warn", "skip"]:
+    if on_error and on_error.lower() not in ["fail", "warn", "skip"]:
         raise ValueError(f"'on_error' {on_error} not a valid value. Choose fail, warn or skip.")
     _warn_ignored_keywords(options)
 

--- a/ibridges/executor.py
+++ b/ibridges/executor.py
@@ -15,9 +15,9 @@ import irods.keywords as kw
 from tqdm import tqdm
 from tqdm.std import tqdm as tqdm_type
 
+from ibridges.exception import FileTransferFailedError, ObjectTransferFailedError
 from ibridges.path import IrodsPath
 from ibridges.session import Session
-from ibridges.exception import FileTransferFailedError, ObjectTransferFailedError
 
 NUM_THREADS = 4
 
@@ -459,7 +459,6 @@ def _obj_get(
     pbar: Optional[tqdm_type] = None,
 ):
     # pylint: disable=W0718,R0915,R0912
-
     """Download `irods_path` to `local_path` following iRODS `options`.
 
     Parameters

--- a/ibridges/executor.py
+++ b/ibridges/executor.py
@@ -11,6 +11,7 @@ from typing import Optional, Union
 import irods.collection
 import irods.data_object
 import irods.exception
+from irods.exception import CollectionDoesNotExist
 import irods.keywords as kw
 from tqdm import tqdm
 from tqdm.std import tqdm as tqdm_type
@@ -148,7 +149,7 @@ class Operations():  # pylint: disable=too-many-instance-attributes
         """
         self.create_collection.add(str(new_col))
 
-    def execute(self, session: Session, ignore_err: bool = False,
+    def execute(self, session: Session, on_err: str = "fail",
                 progress_bar: bool = True):
         """Execute all added operations.
 
@@ -158,9 +159,10 @@ class Operations():  # pylint: disable=too-many-instance-attributes
         ----------
         session
             Session to perform the operations with.
-        ignore_err, optional
-            Whether to ignore errors when encountered, by default False
-            Note that not all errors will be ignored.
+        on_err, optional
+            'fail': Stop execution and throw exception
+            'warn': Continue execution but show a warning
+            'skip': Continue execution and skip the error
         progress_bar
             Whether to turn on the progress bar. The progress bar will be disabled
             if the total download + upload size is 0 regardless.
@@ -178,13 +180,13 @@ class Operations():  # pylint: disable=too-many-instance-attributes
         )
         self.execute_create_dir()
         self.execute_create_coll(session)
-        self.execute_download(session, pbar, ignore_err=ignore_err)
-        self.execute_upload(session, pbar, ignore_err=ignore_err)
+        self.execute_download(session, pbar, on_err=on_err)
+        self.execute_upload(session, pbar, on_err=on_err)
         self.execute_meta_download()
         self.execute_meta_upload()
 
     def execute_download(self, session: Session,
-                         pbar: Optional[tqdm_type], ignore_err: bool = False):
+                         pbar: Optional[tqdm_type], on_err: str = "fail"):
         """Execute all download operations.
 
         Parameters
@@ -195,8 +197,10 @@ class Operations():  # pylint: disable=too-many-instance-attributes
             Sizes of the data objects to be downloaded.
         pbar
             The progress bar to be updated.
-        ignore_err, optional
-            Whether to ignore errors when encountered, by default False.
+        on_err, optional
+            'fail': Stop execution and throw exception
+            'warn': Continue execution but show a warning
+            'skip': Continue execution and skip the error
 
         """
         for ipath, lpath in self.download:
@@ -205,14 +209,14 @@ class Operations():  # pylint: disable=too-many-instance-attributes
                 ipath,
                 lpath,
                 overwrite=True,
-                ignore_err=ignore_err,
+                on_err=on_err,
                 options=self.options,
                 resc_name=self.resc_name,
                 pbar=pbar,
             )
 
     def execute_upload(self, session: Session,
-                       pbar: Optional[tqdm_type], ignore_err: bool = False):
+                       pbar: Optional[tqdm_type], on_err: str = "fail"):
         """Execute all upload operations.
 
         Parameters
@@ -223,9 +227,10 @@ class Operations():  # pylint: disable=too-many-instance-attributes
             Sizes of the files to be uploaded.
         pbar
             Progress bar to be updated while uploading.
-        ignore_err
-            Whether to ignore errors when encountered, by default False.
-
+        on_err, optional
+            'fail': Stop execution and throw exception
+            'warn': Continue execution but show a warning
+            'skip': Continue execution and skip the error
         """
         for lpath, ipath in self.upload:
             _obj_put(
@@ -233,7 +238,7 @@ class Operations():  # pylint: disable=too-many-instance-attributes
                 lpath,
                 ipath,
                 overwrite=True,
-                ignore_err=ignore_err,
+                on_err=on_err,
                 options=self.options,
                 resc_name=self.resc_name,
                 pbar=pbar,
@@ -344,6 +349,19 @@ def _warn_ignored_keywords(options: Optional[dict]):
         warnings.warn(f"Some options will be ignored: {cur_ignored_set}", UserWarning)
 
 
+def _raise_transfer_errors(on_err: str,
+                           msg: str,
+                           throw_error: Exception,
+                           error: Optional[Exception] = None):
+    if on_err == "fail":
+        if error:
+            raise throw_error(msg) from error
+        else:
+            raise throw_error(msg)
+    elif on_err == "warn":
+        warnings.warn(msg)
+
+
 def _obj_put(  # pylint: disable=too-many-branches
     session: Session,
     local_path: Union[str, Path],
@@ -351,10 +369,10 @@ def _obj_put(  # pylint: disable=too-many-branches
     overwrite: bool = False,
     resc_name: str = "",
     options: Optional[dict] = None,
-    ignore_err: bool = False,
+    on_err: str = "fail",
     pbar: Optional[tqdm_type] = None,
 ):
-    # pylint: disable=W0718,R0915,R0912
+    # ylint: disable=W0718,R0915,R0912
     """Upload `local_path` to `irods_path` following iRODS `options`.
 
     Parameters
@@ -371,20 +389,22 @@ def _obj_put(  # pylint: disable=too-many-branches
         Whether to overwrite the object if it exists.
     options :
         Extra options to the python irodsclient put method.
-    ignore_err:
-        If True, convert errors into warnings.
+    on_err:
+        'fail': fail with an exception; 'warn': turn error into warning and continue;
+        'skip': simply continue.
     pbar:
         Optional progress bar.
 
     """
+    if on_err.lower() not in ['fail', 'warn', 'skip']:
+        raise ValueError(f"'on_err' {on_err} not a valid value. Choose fail, warn or skip.")
+
     local_path = Path(local_path)
     irods_path = IrodsPath(session, irods_path)
 
     if not local_path.is_file():
         err_msg = f"local_path '{local_path}' must be a file."
-        if not ignore_err:
-            raise ValueError(err_msg)
-        warnings.warn(err_msg)
+        _raise_transfer_errors(on_err, err_msg, ValueError)
         return
 
     # Check if irods object already exists
@@ -413,37 +433,29 @@ def _obj_put(  # pylint: disable=too-many-branches
             session.irods_session.data_objects.put(local_path, str(irods_path), **options)
         except (PermissionError, OSError) as error:
             err_msg = f"Cannot read {error.filename}."
-            if not ignore_err:
-                raise PermissionError(err_msg) from error
-            warnings.warn(err_msg)
+            _raise_transfer_errors(on_err, err_msg, error, error)
+            return
         except irods.exception.CAT_NO_ACCESS_PERMISSION as error:
-            err_msg = f"Cannot write {str(irods_path)}."
-            if not ignore_err:
-                raise PermissionError(err_msg) from error
-            warnings.warn(err_msg)
+            err_msg = f"Cannot write iRODS path {str(irods_path)}."
+            _raise_transfer_errors(on_err, err_msg, PermissionError, error)
+            return
         except irods.exception.OVERWRITE_WITHOUT_FORCE_FLAG as error:
             # This should generally not occur, but a race condition might trigger this.
             # obj does not exist -> someone else writes to object -> overwrite error
-            if not ignore_err:
-                raise FileExistsError(
-                    f"Dataset {irods_path} already exists. "
-                    "Use overwrite=True to overwrite the existing file."
-                    "This error might be the result of simultaneous writing "
-                    "to the same data object."
-                ) from error
+            err_msg = (f"Dataset {irods_path} already exists. "
+                       "Use overwrite=True to overwrite the existing file."
+                       "This error might be the result of simultaneous writing "
+                       "to the same data object.")
+            _raise_transfer_errors(on_err, err_msg, FileExistsError, error)
+            return
         except Exception as error:
-            if not ignore_err:
-                msg = f"Cannot transfer {local_path} to {irods_path}, {repr(error)}"
-                raise FileTransferFailedError(msg) from error
-            warnings.warn(msg)
+            err_msg = f"Cannot transfer {local_path} to {irods_path}, {repr(error)}"
+            _raise_transfer_errors(on_err, err_msg, FileTransferFailedError, error)
+            return
     else:
-        if not ignore_err:
-            raise FileExistsError(
-                f"Dataset {irods_path} already exists. "
-                "Use overwrite=True to overwrite the existing file."
-            )
-        warnings.warn(f"Cannot overwrite dataobject with name '{local_path.name}',"
-                      "it already exists. Use overwrite=False to suppress this warning.")
+        err_msg = (f"Dataset {irods_path} already exists. "
+                    "Use overwrite=True to overwrite the existing file.")
+        _raise_transfer_errors(on_err, err_msg, FileExistsError)
     if pbar is not None and not upd_put:
         pbar.update(IrodsPath(session, irods_path).size)
 
@@ -455,7 +467,7 @@ def _obj_get(
     overwrite: bool = False,
     resc_name: Optional[str] = "",
     options: Optional[dict] = None,
-    ignore_err: bool = False,
+    on_err: str = "fail",
     pbar: Optional[tqdm_type] = None,
 ):
     # pylint: disable=W0718,R0915,R0912
@@ -475,12 +487,15 @@ def _obj_get(
         Name of the resource to get the object from.
     options : dict
         Extra options to the python irodsclient get method.
-    ignore_err:
-        If True, convert errors into warnings.
+    on_err:
+        'fail': fail with an exception; 'warn': turn error into warning and continue
+        'skip': simply continue. 
     pbar:
         Optional progress bar.
 
     """
+    if on_err.lower() not in ["fail", "warn", "skip"]:
+        raise ValueError(f"'on_err' {on_err} not a valid value. Choose fail, warn or skip.")
     _warn_ignored_keywords(options)
 
     if options is None:
@@ -510,19 +525,21 @@ def _obj_get(
         session.irods_session.data_objects.get(str(irods_path), local_path, **options)
     except (OSError, irods.exception.CAT_NO_ACCESS_PERMISSION) as error:
         msg = f"Cannot write to {local_path}."
-        if not ignore_err:
-            raise PermissionError(msg) from error
-        warnings.warn(msg)
-    except irods.exception.CUT_ACTION_PROCESSED_ERR as exc:
+        _raise_transfer_errors(on_err, msg, PermissionError, error)
+        return
+    except irods.exception.CUT_ACTION_PROCESSED_ERR as error:
         msg = f"During download operation from '{irods_path}': iRODS server forbids action."
-        if not ignore_err:
-            raise PermissionError(msg) from exc
-        warnings.warn(msg)
+        _raise_transfer_errors(on_err, msg, PermissionError, error)
+        return
+    except irods.exception.CollectionDoesNotExist as error:
+        msg = f"{irods_path} does not exist."
+        exception = CollectionDoesNotExist(msg)
+        _raise_transfer_errors(on_err, msg, ObjectTransferFailedError, exception)
+        return
     except Exception as error:
         msg = f"Cannot transfer {irods_path} to {local_path}, {repr(error)}"
-        if not ignore_err:
-            raise ObjectTransferFailedError from error
-        warnings.warn(msg)
+        _raise_transfer_errors(on_err, msg, ObjectTransferFailedError, error)
+        return
     if pbar is not None and not upd_put:
         pbar.update(IrodsPath(session, irods_path).size)
 

--- a/ibridges/executor.py
+++ b/ibridges/executor.py
@@ -160,9 +160,8 @@ class Operations():  # pylint: disable=too-many-instance-attributes
         session
             Session to perform the operations with.
         on_error, optional
-            'fail': Stop execution and throw exception
-            'warn': Continue execution but show a warning
-            'skip': Continue execution and skip the error
+            Decides what happens when an error occurs.
+            There are three options: 'fail', 'warn' and 'skip'.
         progress_bar
             Whether to turn on the progress bar. The progress bar will be disabled
             if the total download + upload size is 0 regardless.
@@ -198,9 +197,8 @@ class Operations():  # pylint: disable=too-many-instance-attributes
         pbar
             The progress bar to be updated.
         on_error, optional
-            'fail': Stop execution and throw exception
-            'warn': Continue execution but show a warning
-            'skip': Continue execution and skip the error
+            Decides what happens when an error occurs.
+            There are three options: 'fail', 'warn' and 'skip'.
 
         """
         for ipath, lpath in self.download:
@@ -228,9 +226,8 @@ class Operations():  # pylint: disable=too-many-instance-attributes
         pbar
             Progress bar to be updated while uploading.
         on_error, optional
-            'fail': Stop execution and throw exception
-            'warn': Continue execution but show a warning
-            'skip': Continue execution and skip the error
+            Decides what happens when an error occurs.
+            There are three options: 'fail', 'warn' and 'skip'.
 
         """
         for lpath, ipath in self.upload:

--- a/ibridges/executor.py
+++ b/ibridges/executor.py
@@ -11,8 +11,8 @@ from typing import Optional, Union
 import irods.collection
 import irods.data_object
 import irods.exception
-from irods.exception import CollectionDoesNotExist
 import irods.keywords as kw
+from irods.exception import CollectionDoesNotExist
 from tqdm import tqdm
 from tqdm.std import tqdm as tqdm_type
 
@@ -231,6 +231,7 @@ class Operations():  # pylint: disable=too-many-instance-attributes
             'fail': Stop execution and throw exception
             'warn': Continue execution but show a warning
             'skip': Continue execution and skip the error
+
         """
         for lpath, ipath in self.upload:
             _obj_put(
@@ -356,9 +357,8 @@ def _raise_transfer_errors(on_err: str,
     if on_err == "fail":
         if error:
             raise throw_error(msg) from error
-        else:
-            raise throw_error(msg)
-    elif on_err == "warn":
+        raise throw_error(msg)
+    if on_err == "warn":
         warnings.warn(msg)
 
 
@@ -372,7 +372,6 @@ def _obj_put(  # pylint: disable=too-many-branches
     on_err: str = "fail",
     pbar: Optional[tqdm_type] = None,
 ):
-    # ylint: disable=W0718,R0915,R0912
     """Upload `local_path` to `irods_path` following iRODS `options`.
 
     Parameters
@@ -448,7 +447,7 @@ def _obj_put(  # pylint: disable=too-many-branches
                        "to the same data object.")
             _raise_transfer_errors(on_err, err_msg, FileExistsError, error)
             return
-        except Exception as error:
+        except Exception as error: # pylint: disable=W0718
             err_msg = f"Cannot transfer {local_path} to {irods_path}, {repr(error)}"
             _raise_transfer_errors(on_err, err_msg, FileTransferFailedError, error)
             return
@@ -489,7 +488,7 @@ def _obj_get(
         Extra options to the python irodsclient get method.
     on_err:
         'fail': fail with an exception; 'warn': turn error into warning and continue
-        'skip': simply continue. 
+        'skip': simply continue.
     pbar:
         Optional progress bar.
 
@@ -531,7 +530,7 @@ def _obj_get(
         msg = f"During download operation from '{irods_path}': iRODS server forbids action."
         _raise_transfer_errors(on_err, msg, PermissionError, error)
         return
-    except irods.exception.CollectionDoesNotExist as error:
+    except irods.exception.CollectionDoesNotExist:
         msg = f"{irods_path} does not exist."
         exception = CollectionDoesNotExist(msg)
         _raise_transfer_errors(on_err, msg, ObjectTransferFailedError, exception)

--- a/ibridges/executor.py
+++ b/ibridges/executor.py
@@ -149,7 +149,7 @@ class Operations():  # pylint: disable=too-many-instance-attributes
         """
         self.create_collection.add(str(new_col))
 
-    def execute(self, session: Session, on_err: str = "fail",
+    def execute(self, session: Session, on_error: str = "fail",
                 progress_bar: bool = True):
         """Execute all added operations.
 
@@ -159,7 +159,7 @@ class Operations():  # pylint: disable=too-many-instance-attributes
         ----------
         session
             Session to perform the operations with.
-        on_err, optional
+        on_error, optional
             'fail': Stop execution and throw exception
             'warn': Continue execution but show a warning
             'skip': Continue execution and skip the error
@@ -180,13 +180,13 @@ class Operations():  # pylint: disable=too-many-instance-attributes
         )
         self.execute_create_dir()
         self.execute_create_coll(session)
-        self.execute_download(session, pbar, on_err=on_err)
-        self.execute_upload(session, pbar, on_err=on_err)
+        self.execute_download(session, pbar, on_error=on_error)
+        self.execute_upload(session, pbar, on_error=on_error)
         self.execute_meta_download()
         self.execute_meta_upload()
 
     def execute_download(self, session: Session,
-                         pbar: Optional[tqdm_type], on_err: str = "fail"):
+                         pbar: Optional[tqdm_type], on_error: str = "fail"):
         """Execute all download operations.
 
         Parameters
@@ -197,7 +197,7 @@ class Operations():  # pylint: disable=too-many-instance-attributes
             Sizes of the data objects to be downloaded.
         pbar
             The progress bar to be updated.
-        on_err, optional
+        on_error, optional
             'fail': Stop execution and throw exception
             'warn': Continue execution but show a warning
             'skip': Continue execution and skip the error
@@ -209,14 +209,14 @@ class Operations():  # pylint: disable=too-many-instance-attributes
                 ipath,
                 lpath,
                 overwrite=True,
-                on_err=on_err,
+                on_error=on_error,
                 options=self.options,
                 resc_name=self.resc_name,
                 pbar=pbar,
             )
 
     def execute_upload(self, session: Session,
-                       pbar: Optional[tqdm_type], on_err: str = "fail"):
+                       pbar: Optional[tqdm_type], on_error: str = "fail"):
         """Execute all upload operations.
 
         Parameters
@@ -227,7 +227,7 @@ class Operations():  # pylint: disable=too-many-instance-attributes
             Sizes of the files to be uploaded.
         pbar
             Progress bar to be updated while uploading.
-        on_err, optional
+        on_error, optional
             'fail': Stop execution and throw exception
             'warn': Continue execution but show a warning
             'skip': Continue execution and skip the error
@@ -239,7 +239,7 @@ class Operations():  # pylint: disable=too-many-instance-attributes
                 lpath,
                 ipath,
                 overwrite=True,
-                on_err=on_err,
+                on_error=on_error,
                 options=self.options,
                 resc_name=self.resc_name,
                 pbar=pbar,
@@ -350,15 +350,15 @@ def _warn_ignored_keywords(options: Optional[dict]):
         warnings.warn(f"Some options will be ignored: {cur_ignored_set}", UserWarning)
 
 
-def _raise_transfer_errors(on_err: str,
+def _raise_transfer_errors(on_error: str,
                            msg: str,
                            throw_error,
                            error: Optional[Exception] = None):
-    if on_err == "fail":
+    if on_error == "fail":
         if error:
             raise throw_error(msg) from error
         raise throw_error(msg)
-    if on_err == "warn":
+    if on_error == "warn":
         warnings.warn(msg)
 
 
@@ -369,7 +369,7 @@ def _obj_put(  # pylint: disable=too-many-branches
     overwrite: bool = False,
     resc_name: str = "",
     options: Optional[dict] = None,
-    on_err: str = "fail",
+    on_error: str = "fail",
     pbar: Optional[tqdm_type] = None,
 ):
     """Upload `local_path` to `irods_path` following iRODS `options`.
@@ -388,22 +388,22 @@ def _obj_put(  # pylint: disable=too-many-branches
         Whether to overwrite the object if it exists.
     options :
         Extra options to the python irodsclient put method.
-    on_err:
+    on_error:
         'fail': fail with an exception; 'warn': turn error into warning and continue;
         'skip': simply continue.
     pbar:
         Optional progress bar.
 
     """
-    if on_err.lower() not in ['fail', 'warn', 'skip']:
-        raise ValueError(f"'on_err' {on_err} not a valid value. Choose fail, warn or skip.")
+    if on_error.lower() not in ['fail', 'warn', 'skip']:
+        raise ValueError(f"'on_error' {on_error} not a valid value. Choose fail, warn or skip.")
 
     local_path = Path(local_path)
     irods_path = IrodsPath(session, irods_path)
 
     if not local_path.is_file():
         err_msg = f"local_path '{local_path}' must be a file."
-        _raise_transfer_errors(on_err, err_msg, ValueError)
+        _raise_transfer_errors(on_error, err_msg, ValueError)
         return
 
     # Check if irods object already exists
@@ -432,11 +432,11 @@ def _obj_put(  # pylint: disable=too-many-branches
             session.irods_session.data_objects.put(local_path, str(irods_path), **options)
         except (PermissionError, OSError) as error:
             err_msg = f"Cannot read {error.filename}."
-            _raise_transfer_errors(on_err, err_msg, error, error)
+            _raise_transfer_errors(on_error, err_msg, error, error)
             return
         except irods.exception.CAT_NO_ACCESS_PERMISSION as error:
             err_msg = f"Cannot write iRODS path {str(irods_path)}."
-            _raise_transfer_errors(on_err, err_msg, PermissionError, error)
+            _raise_transfer_errors(on_error, err_msg, PermissionError, error)
             return
         except irods.exception.OVERWRITE_WITHOUT_FORCE_FLAG as error:
             # This should generally not occur, but a race condition might trigger this.
@@ -445,16 +445,16 @@ def _obj_put(  # pylint: disable=too-many-branches
                        "Use overwrite=True to overwrite the existing file."
                        "This error might be the result of simultaneous writing "
                        "to the same data object.")
-            _raise_transfer_errors(on_err, err_msg, FileExistsError, error)
+            _raise_transfer_errors(on_error, err_msg, FileExistsError, error)
             return
         except Exception as error: # pylint: disable=W0718
             err_msg = f"Cannot transfer {local_path} to {irods_path}, {repr(error)}"
-            _raise_transfer_errors(on_err, err_msg, FileTransferFailedError, error)
+            _raise_transfer_errors(on_error, err_msg, FileTransferFailedError, error)
             return
     else:
         err_msg = (f"Dataset {irods_path} already exists. "
                     "Use overwrite=True to overwrite the existing file.")
-        _raise_transfer_errors(on_err, err_msg, FileExistsError)
+        _raise_transfer_errors(on_error, err_msg, FileExistsError)
     if pbar is not None and not upd_put:
         pbar.update(IrodsPath(session, irods_path).size)
 
@@ -466,7 +466,7 @@ def _obj_get(
     overwrite: bool = False,
     resc_name: Optional[str] = "",
     options: Optional[dict] = None,
-    on_err: str = "fail",
+    on_error: str = "fail",
     pbar: Optional[tqdm_type] = None,
 ):
     # pylint: disable=W0718,R0915,R0912
@@ -486,15 +486,15 @@ def _obj_get(
         Name of the resource to get the object from.
     options : dict
         Extra options to the python irodsclient get method.
-    on_err:
+    on_error:
         'fail': fail with an exception; 'warn': turn error into warning and continue
         'skip': simply continue.
     pbar:
         Optional progress bar.
 
     """
-    if on_err.lower() not in ["fail", "warn", "skip"]:
-        raise ValueError(f"'on_err' {on_err} not a valid value. Choose fail, warn or skip.")
+    if on_error.lower() not in ["fail", "warn", "skip"]:
+        raise ValueError(f"'on_error' {on_error} not a valid value. Choose fail, warn or skip.")
     _warn_ignored_keywords(options)
 
     if options is None:
@@ -524,20 +524,20 @@ def _obj_get(
         session.irods_session.data_objects.get(str(irods_path), local_path, **options)
     except (OSError, irods.exception.CAT_NO_ACCESS_PERMISSION) as error:
         msg = f"Cannot write to {local_path}."
-        _raise_transfer_errors(on_err, msg, PermissionError, error)
+        _raise_transfer_errors(on_error, msg, PermissionError, error)
         return
     except irods.exception.CUT_ACTION_PROCESSED_ERR as error:
         msg = f"During download operation from '{irods_path}': iRODS server forbids action."
-        _raise_transfer_errors(on_err, msg, PermissionError, error)
+        _raise_transfer_errors(on_error, msg, PermissionError, error)
         return
     except irods.exception.CollectionDoesNotExist:
         msg = f"{irods_path} does not exist."
         exception = CollectionDoesNotExist(msg)
-        _raise_transfer_errors(on_err, msg, ObjectTransferFailedError, exception)
+        _raise_transfer_errors(on_error, msg, ObjectTransferFailedError, exception)
         return
     except Exception as error:
         msg = f"Cannot transfer {irods_path} to {local_path}, {repr(error)}"
-        _raise_transfer_errors(on_err, msg, ObjectTransferFailedError, error)
+        _raise_transfer_errors(on_error, msg, ObjectTransferFailedError, error)
         return
     if pbar is not None and not upd_put:
         pbar.update(IrodsPath(session, irods_path).size)

--- a/ibridges/executor.py
+++ b/ibridges/executor.py
@@ -17,6 +17,7 @@ from tqdm.std import tqdm as tqdm_type
 
 from ibridges.path import IrodsPath
 from ibridges.session import Session
+from ibridges.exception import FileTransferFailedError, ObjectTransferFailedError
 
 NUM_THREADS = 4
 
@@ -429,6 +430,11 @@ def _obj_put(  # pylint: disable=too-many-branches
                     "This error might be the result of simultaneous writing "
                     "to the same data object."
                 ) from error
+        except Exception as error:
+            if not ignore_err:
+                msg = f"Cannot transfer {local_path} to {irods_path}, {repr(error)}"
+                raise FileTransferFailedError(msg)
+            warnings.warn(msg)
     else:
         if not ignore_err:
             raise FileExistsError(
@@ -509,6 +515,11 @@ def _obj_get(
         msg = f"During download operation from '{irods_path}': iRODS server forbids action."
         if not ignore_err:
             raise PermissionError(msg) from exc
+        warnings.warn(msg)
+    except Exception as error:
+        msg = f"Cannot transfer {irods_path} to {local_path}, {repr(error)}"
+        if not ignore_err:
+            raise ObjectTransferFailedError
         warnings.warn(msg)
     if pbar is not None and not upd_put:
         pbar.update(IrodsPath(session, irods_path).size)

--- a/ibridges/executor.py
+++ b/ibridges/executor.py
@@ -352,7 +352,7 @@ def _warn_ignored_keywords(options: Optional[dict]):
 
 def _raise_transfer_errors(on_err: str,
                            msg: str,
-                           throw_error: Exception,
+                           throw_error,
                            error: Optional[Exception] = None):
     if on_err == "fail":
         if error:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,8 @@ max-positional-arguments=11  # pylint: disable=unrecognized-option
 
 # [tool.pylint.'MESSAGES CONTROL']
 # disable="too-many-positional-arguments"
+[tool.pylint."MESSAGES CONTROL"]
+disable = ["R0801"]
 
 [tool.ruff]
 exclude = ["_version.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ max-positional-arguments=11  # pylint: disable=unrecognized-option
 # [tool.pylint.'MESSAGES CONTROL']
 # disable="too-many-positional-arguments"
 [tool.pylint."MESSAGES CONTROL"]
-disable = ["R0801"]
+disable="duplicate-code"
 
 [tool.ruff]
 exclude = ["_version.py"]


### PR DESCRIPTION
Sometimes bad things happen to file or object names which hamper the data transfer. 
I added a catch all errors clause failing or warning with the source path, destination path  and actual error message. 