### PR TITLE
Remove session as parameter from data operations

### DIFF
--- a/docker/irods_client/tests/conftest.py
+++ b/docker/irods_client/tests/conftest.py
@@ -47,7 +47,8 @@ def testdata():
 
 @pytest.fixture(scope="session")
 def collection(session):
-    coll = IrodsPath.create_collection(session, "test_collection")
+    ipath = IrodsPath(session, "~", "test_collection")
+    coll = IrodsPath.create_collection(session, ipath)
     yield coll
     IrodsPath(session, coll.path).remove()
 

--- a/docker/irods_client/tests/conftest.py
+++ b/docker/irods_client/tests/conftest.py
@@ -48,7 +48,7 @@ def testdata():
 @pytest.fixture(scope="session")
 def collection(session):
     ipath = IrodsPath(session, "~", "test_collection")
-    coll = IrodsPath.create_collection(session, ipath)
+    coll = ipath.create_collection()
     yield coll
     IrodsPath(session, coll.path).remove()
 

--- a/docker/irods_client/tests/conftest.py
+++ b/docker/irods_client/tests/conftest.py
@@ -56,6 +56,6 @@ def collection(session):
 @pytest.fixture(scope="session")
 def dataobject(session, testdata):
     ipath = IrodsPath(session, "~", "bunny.rtf")
-    upload(session, testdata/"bunny.rtf", IrodsPath(session, "~"), overwrite=True)
+    upload(testdata/"bunny.rtf", IrodsPath(session, "~"), overwrite=True)
     yield ipath.dataobject
     ipath.remove()

--- a/docker/irods_client/tests/conftest.py
+++ b/docker/irods_client/tests/conftest.py
@@ -5,10 +5,7 @@ import pytest
 import tomli
 
 from ibridges import Session
-from ibridges.data_operations import (
-    create_collection,
-    upload,
-)
+from ibridges.data_operations import upload
 from ibridges.path import IrodsPath
 
 
@@ -50,7 +47,7 @@ def testdata():
 
 @pytest.fixture(scope="session")
 def collection(session):
-    coll = create_collection(session, IrodsPath(session, "~", "test_collection"))
+    coll = IrodsPath.create_collection(session, "test_collection")
     yield coll
     IrodsPath(session, coll.path).remove()
 

--- a/docker/irods_client/tests/test_cli.py
+++ b/docker/irods_client/tests/test_cli.py
@@ -78,7 +78,7 @@ def test_upload_download_cli(session, config, testdata, tmpdir, irods_env_file, 
     # Upload a directory and check if the dataobjects and collections are created.
     ipath = IrodsPath(session, "~", "test")
     ipath.remove()
-    IrodsPath.create_collection(session, ipath)
+    ipath.create_collection()
     subprocess.run(["ibridges", "upload", testdata, "irods:~/test", "--overwrite"], **pass_opts)
     for fname in testdata.glob("*"):
         assert ((ipath / "testdata" / fname.name).dataobject_exists()
@@ -161,7 +161,7 @@ def test_list_cli(config, pass_opts, irods_env_file, collection):
 def test_search_cli(session, config, pass_opts, irods_env_file, testdata, search, nlines):
     subprocess.run(["ibridges", "init", irods_env_file], **pass_opts)
     ipath_coll = IrodsPath(session, "test_search_x", "test_search")
-    IrodsPath.create_collection(session, ipath_coll)
+    ipath_coll.create_collection()
     subprocess.run(["ibridges", "sync", testdata, "irods:test_search_x/test_search"], **pass_opts)
     assert ipath_coll.collection_exists()
     ipath_coll.meta.clear()

--- a/docker/irods_client/tests/test_cli.py
+++ b/docker/irods_client/tests/test_cli.py
@@ -7,7 +7,6 @@ import pytest
 from pytest import mark
 
 from ibridges import IrodsPath
-from ibridges.data_operations import create_collection
 from ibridges.meta import MetaData
 
 
@@ -79,7 +78,7 @@ def test_upload_download_cli(session, config, testdata, tmpdir, irods_env_file, 
     # Upload a directory and check if the dataobjects and collections are created.
     ipath = IrodsPath(session, "~", "test")
     ipath.remove()
-    create_collection(session, ipath)
+    IrodsPath.create_collection(session, ipath)
     subprocess.run(["ibridges", "upload", testdata, "irods:~/test", "--overwrite"], **pass_opts)
     for fname in testdata.glob("*"):
         assert ((ipath / "testdata" / fname.name).dataobject_exists()

--- a/docker/irods_client/tests/test_data_ops.py
+++ b/docker/irods_client/tests/test_data_ops.py
@@ -188,7 +188,7 @@ def test_meta_archive(session, testdata, tmpdir):
         cur_ipath.meta.delete(meta_data[0], meta_data[1])
 
     # Apply the archive and see if it has arrived.
-    apply_meta_archive(session, meta_fp, ipath)
+    apply_meta_archive(meta_fp, ipath)
 
     for cur_ipath, meta_data in meta_list:
         assert meta_data in cur_ipath.meta

--- a/docker/irods_client/tests/test_data_ops.py
+++ b/docker/irods_client/tests/test_data_ops.py
@@ -36,7 +36,7 @@ def _check_count(ops, nlist):
 def test_upload_download_dataset(session, testdata):
     ipath = IrodsPath(session, "~", "plant.rtf")
     ipath.remove()
-    ops = upload(session, testdata/"plant.rtf", IrodsPath(session, "~"))
+    ops = upload(testdata/"plant.rtf", IrodsPath(session, "~"))
     _check_count(ops, [0, 0, 0, 1])
     data_obj = ipath.dataobject
     assert is_dataobject(data_obj)
@@ -46,41 +46,41 @@ def test_upload_download_dataset(session, testdata):
 
     # Check the overwrite and ignore_err parameters
     with pytest.raises(DataObjectExistsError):
-        upload(session, testdata/"plant.rtf", IrodsPath(session))
-    ops = upload(session, testdata/"plant.rtf", IrodsPath(session), overwrite=True)
+        upload(testdata/"plant.rtf", IrodsPath(session))
+    ops = upload(testdata/"plant.rtf", IrodsPath(session), overwrite=True)
     assert len(ops.upload) == 0
     with ipath.open("w") as handle:
         handle.write("test".encode())
-    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=False, on_error='skip')
+    ops = upload(testdata/"plant.rtf", ipath, overwrite=False, on_error='skip')
     assert len(ops.upload) == 0
     with pytest.warns(UserWarning):
-        ops = upload(session, testdata/"plant.rtf", ipath, overwrite=False, on_error='warn')
+        ops = upload(testdata/"plant.rtf", ipath, overwrite=False, on_error='warn')
         assert len(ops.upload) == 0
     
-    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=True, on_error='skip', dry_run=True)
+    ops = upload(testdata/"plant.rtf", ipath, overwrite=True, on_error='skip', dry_run=True)
     assert len(ops.upload) == 1
-    ops = upload(session, testdata/"plant.rtf", ipath, overwrite=True, on_error='warn')
+    ops = upload(testdata/"plant.rtf", ipath, overwrite=True, on_error='warn')
     assert len(ops.upload) == 1
 
     # Test downloading it back
-    ops = download(session, ipath, testdata/"plant.rtf.copy", overwrite=True)
+    ops = download(ipath, testdata/"plant.rtf.copy", overwrite=True)
     assert _check_files_equal(testdata/"plant.rtf.copy", testdata/"plant.rtf")
     _check_count(ops, [0, 0, 1, 0])
 
     # Check overwrite and ignore_err parameters
     lpath = testdata/"plant.rtf.copy"
-    ops = download(session, ipath, lpath, overwrite=True)
+    ops = download(ipath, lpath, overwrite=True)
     assert len(ops.download) == 0
     with pytest.raises(FileExistsError):
-        download(session, ipath, lpath)
-    ops = download(session, ipath, lpath, overwrite=False, on_error='skip')
+        download(ipath, lpath)
+    ops = download(ipath, lpath, overwrite=False, on_error='skip')
     assert len(ops.download) == 0
     with pytest.warns(UserWarning):
-        ops = download(session, ipath, lpath, overwrite=False, on_error='warn')
+        ops = download(ipath, lpath, overwrite=False, on_error='warn')
         assert len(ops.download) == 0
     with ipath.open("w") as handle:
         handle.write("test".encode())
-    ops = download(session, ipath, lpath, overwrite=True)
+    ops = download(ipath, lpath, overwrite=True)
     assert len(ops.download) == 1
     ipath.remove()
     lpath.unlink()
@@ -89,7 +89,7 @@ def test_upload_download_dataset(session, testdata):
 def test_upload_download_collection(session, testdata, tmpdir):
     ipath = IrodsPath(session, "~", "test")
     ipath.remove()
-    ops = upload(session, testdata, ipath)
+    ops = upload(testdata, ipath)
     _check_count(ops, [3, 0, 0, 6])
     collection = ipath.collection
     assert is_collection(collection)
@@ -99,20 +99,20 @@ def test_upload_download_collection(session, testdata, tmpdir):
 
     # Check overwrite and ignore_err parameters
     with pytest.raises(DataObjectExistsError):
-        upload(session, testdata, ipath)
-    ops = upload(session, testdata, ipath, on_error="skip")
+        upload(testdata, ipath)
+    ops = upload(testdata, ipath, on_error="skip")
     _check_count(ops, [0, 0, 0, 0])
     bunny_ipath = (ipath / "testdata" / "bunny.rtf")
     bunny_ipath.remove()
-    ops = upload(session, testdata, ipath, overwrite=True)
+    ops = upload(testdata, ipath, overwrite=True)
     _check_count(ops, [0, 0, 0, 1])
     with bunny_ipath.open("w") as handle:
         handle.write("est".encode())
-    ops = upload(session, testdata, ipath, overwrite=True)
+    ops = upload(testdata, ipath, overwrite=True)
     _check_count(ops, [0, 0, 0, 1])
 
     # Check if the downloaded collection is the same again.
-    ops = download(session, ipath, tmpdir/"test")
+    ops = download(ipath, tmpdir/"test")
     _check_count(ops, [0, 4, 6, 0])
     files = list(testdata.glob("*"))
 
@@ -128,18 +128,18 @@ def test_upload_download_collection(session, testdata, tmpdir):
 
     # Check overwrite and ignore_err parameters
     with pytest.raises(FileExistsError):
-        download(session, ipath, tmpdir/"test")
-    ops = download(session, ipath, tmpdir/"test", overwrite=True)
+        download(ipath, tmpdir/"test")
+    ops = download(ipath, tmpdir/"test", overwrite=True)
     _check_count(ops, [0, 0, 0, 0])
     with bunny_ipath.open("w") as handle:
         handle.write("testxx".encode())
-    ops = download(session, ipath, tmpdir/"test", on_error='skip')
+    ops = download(ipath, tmpdir/"test", on_error='skip')
     _check_count(ops, [0, 0, 0, 0])
-    ops = download(session, ipath, tmpdir/"test", on_error='warn')
+    ops = download(ipath, tmpdir/"test", on_error='warn')
     _check_count(ops, [0, 0, 0, 0])
-    ops = download(session, ipath, tmpdir/"test", overwrite='skip', dry_run=True)
+    ops = download(ipath, tmpdir/"test", overwrite='skip', dry_run=True)
     _check_count(ops, [0, 0, 1, 0])
-    ops = download(session, ipath, tmpdir/"test", overwrite='warn')
+    ops = download(ipath, tmpdir/"test", overwrite='warn')
     _check_count(ops, [0, 0, 1, 0])
     ipath.remove()
 
@@ -147,7 +147,7 @@ def test_upload_download_collection(session, testdata, tmpdir):
 def test_meta_archive(session, testdata, tmpdir):
     ipath = IrodsPath(session, "test")
     ipath.remove()
-    sync(session, testdata, ipath)
+    sync(testdata, ipath)
     assert len(list(ipath.meta)) == 0
     meta_list = [
         (ipath, ("root", "true", "")),
@@ -195,7 +195,7 @@ def test_meta_archive(session, testdata, tmpdir):
 
 def test_ignored_keyword(session, tmpdir, dataobject):
     with pytest.warns(UserWarning):
-        download(session, dataobject.path, tmpdir, options={kw.NUM_THREADS_KW: 3})
+        download(dataobject.path, tmpdir, options={kw.NUM_THREADS_KW: 3})
     with pytest.warns(UserWarning):
-        upload(session, str(tmpdir/"bunny.rtf"), "~/tmp.rtf", options={kw.NUM_THREADS_KW: 3})
+        upload(str(tmpdir/"bunny.rtf"), "~/tmp.rtf", options={kw.NUM_THREADS_KW: 3})
     IrodsPath(session, "~/tmp.rtf").remove()

--- a/docker/irods_client/tests/test_data_ops.py
+++ b/docker/irods_client/tests/test_data_ops.py
@@ -157,7 +157,7 @@ def test_meta_archive(session, testdata, tmpdir):
     for cur_ipath, meta_data in meta_list:
         cur_ipath.meta.add(*meta_data)
     meta_fp = tmpdir / "meta.json"
-    create_meta_archive(session, ipath, meta_fp)
+    create_meta_archive(ipath, meta_fp)
     with open(meta_fp, "r") as handle:
         meta_dict = json.load(handle)
 
@@ -195,7 +195,9 @@ def test_meta_archive(session, testdata, tmpdir):
 
 def test_ignored_keyword(session, tmpdir, dataobject):
     with pytest.warns(UserWarning):
-        download(dataobject.path, tmpdir, options={kw.NUM_THREADS_KW: 3})
+        ipath = IrodsPath(session, dataobject.path)
+        download(ipath, tmpdir, options={kw.NUM_THREADS_KW: 3})
     with pytest.warns(UserWarning):
-        upload(str(tmpdir/"bunny.rtf"), "~/tmp.rtf", options={kw.NUM_THREADS_KW: 3})
+        ipath = IrodsPath(session, "~", "tmp.rtf")
+        upload(str(tmpdir/"bunny.rtf"), ipath, options={kw.NUM_THREADS_KW: 3})
     IrodsPath(session, "~/tmp.rtf").remove()

--- a/docker/irods_client/tests/test_meta.py
+++ b/docker/irods_client/tests/test_meta.py
@@ -62,10 +62,23 @@ def test_meta(item_name, request):
 
     meta.add("x", "y")
     meta.add("y", "z")
-    meta.set("y", "x")
+    meta["y"] = "x"
     assert "x" in meta
     assert ("y", "z") not in meta
     assert ("y", "x") in meta
+
+    meta["y"] = [["x", "u"], ["y", "u"]]
+    assert ("y", "x") in meta
+    assert ("y", "y") in meta
+    with pytest.raises(ValueError):
+        meta["y"] = "z"
+    assert ("y", "x") in meta
+    assert ("y", "y") in meta
+    with pytest.raises(ValueError):
+        meta["y"] = [["a", "b", "c"]]
+    meta.delete(key="y")
+    with pytest.raises(ValueError):
+        meta["y"] = "a", "b", "c"
     meta.clear()
 
 @mark.parametrize("item_name", ["collection", "dataobject"])
@@ -143,15 +156,31 @@ def test_metadata_setitem(item_name, request):
     meta = MetaData(item)
     meta.clear()
 
-    meta.add("some_key", "some_value", "some_units")
-    meta["some_key"] = ("some_key", "new_value", "new_units")
-    meta["some_key"] = ("some_key", "new_value")
+    meta["key"] = "value", "units"
+    assert ("key", "value", "units") in meta
 
-    with pytest.raises(TypeError):
-        meta["some_key"] = "new_value"
+    meta["key", "value"] = "other_units"
+    assert ("key", "value", "units") not in meta
+    assert ("key", "value", "other_units") in meta
+    meta["key", "other_value"] = "units"
+    assert ("key", "value", "other_units") in meta
+
+    meta.add("key", "value", "even_units")
+    assert len(meta) == 3
+    with pytest.raises(ValueError):
+        meta["key"] = "new_value"
 
     with pytest.raises(ValueError):
-        meta["some_key"] = ("some_key", "new_value")
+        meta["key", "value"] = "another_units"
+
+    meta["key2"] = "value2"
+    assert len(meta) == 4
+
+    with pytest.raises(ValueError):
+        meta["some_key", "some_value", "some_units"] = ""
+
+    with pytest.raises(ValueError):
+        meta["some_key", "some_value"] = "new_value", "new_units"
 
 
 @mark.parametrize("item_name", ["collection", "dataobject"])

--- a/docker/irods_client/tests/test_path.py
+++ b/docker/irods_client/tests/test_path.py
@@ -52,9 +52,6 @@ def test_path_create_coll(session):
     coll = ipath.create_collection()
     assert coll.path == str(ipath.absolute())
 
-    ipath = IrodsPath(session)
-    with pytest.raises(ValueError):
-        coll = ipath.create_collection()
     ipath = IrodsPath(session, "/NotAZoneName")
     with pytest.raises(ValueError):
         coll.ipath.create_collection()

--- a/docker/irods_client/tests/test_path.py
+++ b/docker/irods_client/tests/test_path.py
@@ -54,4 +54,4 @@ def test_path_create_coll(session):
 
     ipath = IrodsPath(session, "/NotAZoneName")
     with pytest.raises(ValueError):
-        coll.ipath.create_collection()
+        ipath.create_collection()

--- a/docker/irods_client/tests/test_path.py
+++ b/docker/irods_client/tests/test_path.py
@@ -50,7 +50,7 @@ def test_path_open(session):
 def test_path_create_coll(session):
     ipath = IrodsPath(session, "test_collection")
     coll = ipath.create_collection()
-    assert collpath == str(ipath.absolute)
+    assert coll.path == str(ipath.absolute)
 
     ipath = IrodsPath(session)
     with pytest.raises(ValueError):

--- a/docker/irods_client/tests/test_path.py
+++ b/docker/irods_client/tests/test_path.py
@@ -46,3 +46,15 @@ def test_path_open(session):
 
     with ipath.open("r") as handle:
         assert handle.read().decode("utf-8") == test_str_1 + test_str_2
+
+def test_path_create_coll(session):
+    ipath = IrodsPath(session, "test_collection")
+    coll = ipath.create_collection()
+    assert collpath == str(ipath.absolute)
+
+    ipath = IrodsPath(session)
+    with pytest.raises(ValueError):
+        coll = ipath.create_collection()
+    ipath = IrodsPath(session, "/NotAZoneName")
+    with pytest.raises(ValueError):
+        coll.ipath.create_collection()

--- a/docker/irods_client/tests/test_path.py
+++ b/docker/irods_client/tests/test_path.py
@@ -50,7 +50,7 @@ def test_path_open(session):
 def test_path_create_coll(session):
     ipath = IrodsPath(session, "test_collection")
     coll = ipath.create_collection()
-    assert coll.path == str(ipath.absolute)
+    assert coll.path == str(ipath.absolute())
 
     ipath = IrodsPath(session)
     with pytest.raises(ValueError):

--- a/docker/irods_client/tests/test_sync.py
+++ b/docker/irods_client/tests/test_sync.py
@@ -9,8 +9,7 @@ def test_sync_dry_run(session, testdata, capsys):
     assert len(coll.data_objects)+len(coll.subcollections)==0, "Dry run starting not empty"
 
     # upload
-    ops = sync(session=session,
-               source=testdata,
+    ops = sync(source=testdata,
                target=ipath,
                max_level=None,
                dry_run=True,
@@ -30,8 +29,7 @@ def test_sync_upload_download(session, testdata, tmpdir):
     assert len(coll.data_objects)+len(coll.subcollections)==0, "iRODS folder not empty"
 
     # upload
-    sync(session=session,
-         source=testdata,
+    sync(source=testdata,
          target=ipath,
          max_level=None,
          dry_run=False,
@@ -56,8 +54,7 @@ def test_sync_upload_download(session, testdata, tmpdir):
             "Checksums not identical after upload"
 
     # download
-    sync(session=session,
-        source=ipath,
+    sync(source=ipath,
         target=tmpdir,
         max_level=None,
         dry_run=False,

--- a/docker/irods_client/tests/test_sync.py
+++ b/docker/irods_client/tests/test_sync.py
@@ -10,7 +10,7 @@ def test_sync_dry_run(session, testdata, capsys):
 
     # upload
     ops = sync(source=testdata,
-               target=ipath,
+               target=coll,
                max_level=None,
                dry_run=True,
                copy_empty_folders=True)

--- a/docker/irods_client/tests/test_sync.py
+++ b/docker/irods_client/tests/test_sync.py
@@ -5,7 +5,7 @@ from ibridges.util import calc_checksum
 
 def test_sync_dry_run(session, testdata, capsys):
 
-    coll = IrodsPath.create_collection(session, "~", "empty")
+    coll = IrodsPath.create_collection(session, "empty")
     assert len(coll.data_objects)+len(coll.subcollections)==0, "Dry run starting not empty"
 
     # upload
@@ -24,7 +24,7 @@ def test_sync_dry_run(session, testdata, capsys):
 
 def test_sync_upload_download(session, testdata, tmpdir):
     ipath = IrodsPath(session, "~", "empty")
-    coll = create_collection(session=session, coll_path=ipath)
+    coll = IrodsPath.create_collection(session=session, ipath)
 
     assert len(coll.data_objects)+len(coll.subcollections)==0, "iRODS folder not empty"
 

--- a/docker/irods_client/tests/test_sync.py
+++ b/docker/irods_client/tests/test_sync.py
@@ -5,7 +5,7 @@ from ibridges.util import calc_checksum
 
 def test_sync_dry_run(session, testdata, capsys):
 
-    coll = IrodsPath.create_collection(session, "empty")
+    coll = IrodsPath.create_collection(session, session.home+"/empty")
     assert len(coll.data_objects)+len(coll.subcollections)==0, "Dry run starting not empty"
 
     # upload

--- a/docker/irods_client/tests/test_sync.py
+++ b/docker/irods_client/tests/test_sync.py
@@ -1,12 +1,11 @@
-from ibridges.data_operations import create_collection, sync
+from ibridges.data_operations import sync
 from ibridges.path import IrodsPath
 from ibridges.util import calc_checksum
 
 
 def test_sync_dry_run(session, testdata, capsys):
 
-    ipath = IrodsPath(session, "~", "empty")
-    coll = create_collection(session=session, coll_path=ipath)
+    coll = IrodsPath.create_collection(session, "~", "empty")
     assert len(coll.data_objects)+len(coll.subcollections)==0, "Dry run starting not empty"
 
     # upload

--- a/docker/irods_client/tests/test_sync.py
+++ b/docker/irods_client/tests/test_sync.py
@@ -25,7 +25,7 @@ def test_sync_dry_run(session, testdata, capsys):
 
 def test_sync_upload_download(session, testdata, tmpdir):
     ipath = IrodsPath(session, "~", "empty")
-    coll = ipath.create_collection(session, ipath)
+    coll = ipath.create_collection()
 
     assert len(coll.data_objects)+len(coll.subcollections)==0, "iRODS folder not empty"
 

--- a/docker/irods_client/tests/test_sync.py
+++ b/docker/irods_client/tests/test_sync.py
@@ -24,7 +24,7 @@ def test_sync_dry_run(session, testdata, capsys):
 
 def test_sync_upload_download(session, testdata, tmpdir):
     ipath = IrodsPath(session, "~", "empty")
-    coll = IrodsPath.create_collection(session=session, ipath)
+    coll = IrodsPath.create_collection(session, ipath)
 
     assert len(coll.data_objects)+len(coll.subcollections)==0, "iRODS folder not empty"
 

--- a/docker/irods_client/tests/test_sync.py
+++ b/docker/irods_client/tests/test_sync.py
@@ -5,8 +5,8 @@ from ibridges.util import calc_checksum
 
 def test_sync_dry_run(session, testdata, capsys):
 
-    coll = IrodsPath.create_collection(session, session.home+"/empty")
-    ipath = IrodsPath(session, coll.path)
+    ipath = IrodsPath(session, session.home+"/empty")
+    coll = ipath.create_collection()
     assert len(coll.data_objects)+len(coll.subcollections)==0, "Dry run starting not empty"
 
     # upload
@@ -25,7 +25,7 @@ def test_sync_dry_run(session, testdata, capsys):
 
 def test_sync_upload_download(session, testdata, tmpdir):
     ipath = IrodsPath(session, "~", "empty")
-    coll = IrodsPath.create_collection(session, ipath)
+    coll = ipath.create_collection(session, ipath)
 
     assert len(coll.data_objects)+len(coll.subcollections)==0, "iRODS folder not empty"
 

--- a/docker/irods_client/tests/test_sync.py
+++ b/docker/irods_client/tests/test_sync.py
@@ -6,11 +6,12 @@ from ibridges.util import calc_checksum
 def test_sync_dry_run(session, testdata, capsys):
 
     coll = IrodsPath.create_collection(session, session.home+"/empty")
+    ipath = IrodsPath(session, coll.path)
     assert len(coll.data_objects)+len(coll.subcollections)==0, "Dry run starting not empty"
 
     # upload
     ops = sync(source=testdata,
-               target=coll,
+               target=ipath,
                max_level=None,
                dry_run=True,
                copy_empty_folders=True)

--- a/docker/irods_client/tests/test_util.py
+++ b/docker/irods_client/tests/test_util.py
@@ -19,9 +19,9 @@ def test_calc_checksum(irods_env, config, check_type, checksum, testdata, tmp_pa
         ipath_coll = IrodsPath(session, "test_check")
         ipath_coll.remove()
         ipath_coll.create_collection(session, ipath_coll)
-        upload(session, testdata / "bunny.rtf", ipath_coll)
+        upload(testdata / "bunny.rtf", ipath_coll)
         ipath = ipath_coll / "bunny.rtf"
-        download(session, ipath, tmp_path)
+        download(ipath, tmp_path)
         assert calc_checksum(ipath, checksum_type=check_type) == checksum
         assert calc_checksum(tmp_path / "bunny.rtf", checksum_type=check_type) == checksum
         assert checksums_equal(ipath, tmp_path / "bunny.rtf")

--- a/docker/irods_client/tests/test_util.py
+++ b/docker/irods_client/tests/test_util.py
@@ -18,7 +18,7 @@ def test_calc_checksum(irods_env, config, check_type, checksum, testdata, tmp_pa
     with Session(irods_env=ienv, password=config["password"]) as session:
         ipath_coll = IrodsPath(session, "test_check")
         ipath_coll.remove()
-        ipath_coll.create_collection(session, ipath_coll)
+        ipath_coll.create_collection()
         upload(testdata / "bunny.rtf", ipath_coll)
         ipath = ipath_coll / "bunny.rtf"
         download(ipath, tmp_path)

--- a/docs/source/data_transfers.rst
+++ b/docs/source/data_transfers.rst
@@ -36,7 +36,7 @@ If the transfer concerned a folder, a new collection with the folder name will b
  
     local_path = Path("/path/to/the/data/to/upload")
     irods_path = IrodsPath(session, '~', 'new_coll')
-    upload(session, local_path, irods_path)
+    upload(local_path, irods_path)
 
 .. currentmodule:: ibridges.executor
 
@@ -60,7 +60,7 @@ The :func:`download` function works similar to the :func:`upload` function. Simp
    
     local_path = Path("/destination/location/for/the/data")
     irods_path = IrodsPath(session, '~', 'new_coll')
-    download(session, irods_path, local_path)
+    downloadirods_path, local_path)
 
 Synchronisation
 ---------------
@@ -87,7 +87,7 @@ The code below shows how to synchronise from your local file system to iRODS. Th
     source = Path.home() / "<local path>"
 
     # Synchronise the data
-    sync(session=session, source=source, target=target)
+    sync(source=source, target=target)
 
 
 Synchronize from remote to local
@@ -104,7 +104,7 @@ The code below shows how to synchronise from your iRODS instance to your local f
     source = IrodsPath(session, "~", "<irods path>")
 
     # call the synchronisation
-    sync(session=session, source=source, target=target)
+    sync(source=source, target=target)
 
 
 Streaming data objects

--- a/docs/source/metadata.rst
+++ b/docs/source/metadata.rst
@@ -50,14 +50,30 @@ To add metadata, you always need to provide a key and a value, the units are opt
 Set metadata
 ------------
 
-The :meth:`MetaData.set` method differs from the add method by removing all other entries with the
-same key first. This mirrors the implementation of the `iCommands <https://rdm-docs.icts.kuleuven.be/mango/clients/icommands.html#adding-metadata>`__
-:code:`imeta set`.
+You can use the brackets ``[]`` to set a key or key/value pair. The following code creates two entries:
+(ExistingKey, Value, Unit) and (ExistingKey, NewValue, NewUnit). 
+
 
 .. code-block:: python
 
-    meta.set('ExistingKey', 'Value', 'Unit')
+    meta["ExistingKey"] = "Value", "Unit"
+    meta["ExistingKey", "New_Value"] = "New_Unit"
 
+The single assignment notation will only change/set one triplet at the same time. So, for example the following will throw an error:
+
+.. code-block:: python
+
+    meta["ExistingKey"] = "Other_Value", "Other_Unit"
+
+If you want to remove all entries with the key ``ExistingKey`` and set it to one or more new entries, then you can use the double bracket notation:
+
+.. code-block:: python
+
+    meta["ExistingKey"] = [["Other_Value", "Other_Unit"]]
+
+
+This notation mirrors the implementation of the `iCommands <https://rdm-docs.icts.kuleuven.be/mango/clients/icommands.html#adding-metadata>`__
+:code:`imeta set`.
 
 Find metadata items
 -------------------

--- a/ibridges/cli/data_operations.py
+++ b/ibridges/cli/data_operations.py
@@ -149,7 +149,6 @@ class CliDownload(BaseCliCommand):
         metadata = _get_metadata_path(args, ipath, lpath, "download")
         try:
             ops = download(
-                session,
                 ipath,
                 lpath,
                 overwrite=args.overwrite,
@@ -220,7 +219,6 @@ class CliUpload(BaseCliCommand):
         metadata = _get_metadata_path(args, ipath, lpath, "upload")
         try:
             ops = upload(
-                session,
                 lpath,
                 ipath,
                 overwrite=args.overwrite,
@@ -293,7 +291,6 @@ class CliSync(BaseCliCommand):
             return
         try:
             ops = sync(
-                session,
                 src_path,
                 dest_path,
                 dry_run=args.dry_run,

--- a/ibridges/cli/data_operations.py
+++ b/ibridges/cli/data_operations.py
@@ -47,7 +47,7 @@ class CliMakeCollection(BaseCliCommand):
         ipath = parse_remote(args.remote_coll, session)
         if ipath.exists():
             parser.error(f"Cannot create collection {ipath}: already exists.")
-        ipath.create_collection(session, ipath)
+        ipath.create_collection()
 
 
 class CliRm(BaseCliCommand):

--- a/ibridges/cli/shell.py
+++ b/ibridges/cli/shell.py
@@ -215,7 +215,7 @@ def complete_ipath(session, text, line, collections_only=False):  # pylint: disa
 
     base_arg = args[-1]
     base_completion = []
-    if args[-1].startswith("irods"[:len(args[-1])]):
+    if args[-1].startswith("irods:"[:len(args[-1])]):
         if len(args[-1]) < len("irods:"):
             base_completion = [text[:len(text)-len(args[-1])] + "irods:"]
         else:

--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -463,7 +463,7 @@ def apply_meta_archive(meta_fp: Union[str, Path], ipath: IrodsPath, dry_run: boo
 
 
 def _param_checks(source, target):
-    if not isinstance(source, IrodsPath) and not isinstance(target, IrodsPath):
+    if not isinstance(source, IrodsPath) or not isinstance(target, IrodsPath):
         raise TypeError("Either source or target should be an iRODS path.")
 
     if isinstance(source, IrodsPath) and isinstance(target, IrodsPath):

--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -31,9 +31,8 @@ NUM_THREADS = 4
 
 
 def upload(
-    session: Session,
     local_path: Union[str, Path],
-    irods_path: Union[str, IrodsPath],
+    irods_path: IrodsPath,
     overwrite: bool = False,
     ignore_err: bool = False,
     resc_name: str = "",
@@ -47,8 +46,6 @@ def upload(
 
     Parameters
     ----------
-    session:
-        Session to upload the data to.
     local_path:
         Absolute path to the directory to upload
     irods_path:
@@ -91,22 +88,22 @@ def upload(
     --------
     >>> ipath = IrodsPath(session, "~/some_col")
     >>> # Below will create a collection with "~/some_col/dir".
-    >>> upload(session, Path("dir"), ipath)
+    >>> upload(Path("dir"), ipath)
 
     >>> # Same, but now data objects that exist will be overwritten.
-    >>> upload(session, Path("dir"), ipath, overwrite=True)
+    >>> upload(Path("dir"), ipath, overwrite=True)
 
     >>> # Perform the upload in two steps with a dry-run
-    >>> ops = upload(session, Path("some_file.txt"), ipath, dry_run=True)  # Does not upload
+    >>> ops = upload(Path("some_file.txt"), ipath, dry_run=True)  # Does not upload
     >>> ops.print_summary()  # Check if this is what you want here.
     >>> ops.execute()  # Performs the upload
 
     """
     local_path = Path(local_path)
-    ipath = IrodsPath(session, irods_path)
+    session = irods_path.session
     ops = Operations()
     if local_path.is_dir():
-        idest_path = ipath / local_path.name
+        idest_path = irods_path / local_path.name
         if not overwrite and idest_path.dataobject_exists():
             raise DataObjectExistsError(f"Data object {idest_path} already exists.")
         ops = _up_sync_operations(
@@ -115,10 +112,10 @@ def upload(
         )
         if not idest_path.collection_exists():
             ops.add_create_coll(idest_path)
-        if not ipath.collection_exists():
+        if not irods_path.collection_exists():
             ops.add_create_coll(ipath)
     elif local_path.is_file():
-        idest_path = ipath / local_path.name if ipath.collection_exists() else ipath
+        idest_path = irods_path / local_path.name if irods_path.collection_exists() else ipath
         obj_exists = idest_path.dataobject_exists()
         if not obj_exists or _transfer_needed(local_path, idest_path, overwrite, ignore_err):
             ops.add_upload(local_path, idest_path)
@@ -139,8 +136,7 @@ def upload(
 
 
 def download(
-    session: Session,
-    irods_path: Union[str, IrodsPath],
+    irods_path: IrodsPath,
     local_path: Union[str, Path],
     overwrite: bool = False,
     ignore_err: bool = False,
@@ -155,8 +151,6 @@ def download(
 
     Parameters
     ----------
-    session:
-        Session to download the collection from.
     irods_path:
         Absolute irods source path pointing to a collection
     local_path:
@@ -203,17 +197,17 @@ def download(
     Examples
     --------
     >>> # Below will create a directory "some_local_dir/some_collection"
-    >>> download(session, "~/some_collection", "some_local_dir")
+    >>> download(IrodsPath(session, "~/some_collection"), "some_local_dir")
 
     >>> # Below will create a file "some_local_dir/some_obj.txt"
-    >>> download(session, IrodsPath(session, "some_obj.txt"), "some_local_dir")
+    >>> download(IrodsPath(session, "some_obj.txt"), "some_local_dir")
 
     >>> # Below will create a file "new_file.txt" in two steps.
-    >>> ops = download(session, "~/some_obj.txt", "new_file.txt", dry_run=True)
+    >>> ops = download(IrodsPath(session, "some_obj.txt", "new_file.txt", dry_run=True)
     >>> ops.execute()
 
     """
-    irods_path = IrodsPath(session, irods_path)
+    session = irods_path.session
     local_path = Path(local_path)
 
     if irods_path.collection_exists():
@@ -251,36 +245,7 @@ def download(
     return ops
 
 
-def create_collection(
-    session: Session, coll_path: Union[IrodsPath, str]
-) -> irods.collection.iRODSCollection:
-    """Create a collection and all parent collections that do not exist yet.
-
-    Alias for :meth:`ibridges.path.IrodsPath.create_collection`
-
-    Parameters
-    ----------
-    session:
-        Session to create the collection for.
-    coll_path: IrodsPath
-        Collection path
-
-    Raises
-    ------
-    PermissionError:
-        If creating a collection is not allowed by the server.
-
-
-    Examples
-    --------
-    >>> create_collection(session, IrodsPath("~/new_collection"))
-
-    """
-    return IrodsPath.create_collection(session, coll_path)
-
-
 def sync(
-    session: Session,
     source: Union[str, Path, IrodsPath],
     target: Union[str, Path, IrodsPath],
     max_level: Optional[int] = None,
@@ -305,8 +270,6 @@ def sync(
 
     Parameters
     ----------
-    session:
-        An authorized iBridges session.
     source:
         Existing local folder or iRODS collection. An exception will be raised if it doesn't exist.
     target:
@@ -353,15 +316,16 @@ def sync(
     Examples
     --------
     >>> # Below, all files/dirs in "some_local_dir" will be transferred into "some_remote_coll"
-    >>> sync(session, "some_local_dir", IrodsPath(session, "~/some_remote_col")
+    >>> sync("some_local_dir", IrodsPath(session, "~/some_remote_col")
 
     >>> # Below, all data objects/collections in "col" will tbe transferred into "some_local_dir"
-    >>> sync(session, IrodsPath(session, "~/col"), "some_local_dir")
+    >>> sync(IrodsPath(session, "~/col"), "some_local_dir")
 
     """
     _param_checks(source, target)
 
     if isinstance(source, IrodsPath):
+        session = source.session
         if not source.collection_exists():
             if source.dataobject_exists():
                 raise NotACollectionError(f"Source '{source.absolute()}' is a data object, "
@@ -369,6 +333,7 @@ def sync(
             raise CollectionDoesNotExistError(
                 f"Source collection '{source.absolute()}' does not exist")
     else:
+        session = target.session
         if not Path(source).is_dir():
             raise NotADirectoryError(f"Source folder '{source}' is not a directory or "
                                      "does not exist.")
@@ -380,7 +345,7 @@ def sync(
         )
     else:
         ops = _up_sync_operations(
-            Path(source), IrodsPath(session, target), copy_empty_folders=copy_empty_folders,
+            Path(source), target, copy_empty_folders=copy_empty_folders,
             depth=max_level, overwrite=True)
         if metadata is not None:
             ops.add_meta_upload(target, metadata)  # type: ignore
@@ -393,8 +358,7 @@ def sync(
     return ops
 
 
-def create_meta_archive(session: Session, source: Union[str, IrodsPath],
-                        meta_fp: Union[str, Path], dry_run: bool = False):
+def create_meta_archive(root_ipath: IrodsPath, meta_fp: Union[str, Path], dry_run: bool = False):
     """Create a local archive file for the metadata.
 
     The archive is a utf-8 encoded JSON file with the metadata of all subcollections
@@ -402,8 +366,6 @@ def create_meta_archive(session: Session, source: Union[str, IrodsPath],
 
     Parameters
     ----------
-    session
-        Session with the iRODS server.
     source
         Source iRODS path to create the archive for. This should be a collection.
     meta_fp
@@ -425,10 +387,10 @@ def create_meta_archive(session: Session, source: Union[str, IrodsPath],
 
     Examples
     --------
-    >>> create_meta_archive(session, "/some/home/collection", "meta_archive.json")
+    >>> create_meta_archive(IrodsPath(session, "/some/home/collection"), "meta_archive.json")
 
     """
-    root_ipath = IrodsPath(session, source)
+    session = root_ipath.session
     if not root_ipath.collection_exists():
         if root_ipath.dataobject_exists():
             raise NotACollectionError("Cannot download metadata archive: "
@@ -443,8 +405,7 @@ def create_meta_archive(session: Session, source: Union[str, IrodsPath],
     return operations
 
 
-def apply_meta_archive(session, meta_fp: Union[str, Path], ipath: Union[str, IrodsPath],
-                       dry_run: bool = False):
+def apply_meta_archive(meta_fp: Union[str, Path], ipath: IrodsPath, dry_run: bool = False):
     """Apply a metadata archive to set the metadata of collections and data objects.
 
     The archive is a utf-8 encoded JSON file with the metadata of all subcollections
@@ -452,8 +413,6 @@ def apply_meta_archive(session, meta_fp: Union[str, Path], ipath: Union[str, Iro
 
     Parameters
     ----------
-    session
-        Session with the iRODS server.
     meta_fp
         Metadata archive file to use to set the metadata.
     ipath
@@ -476,10 +435,10 @@ def apply_meta_archive(session, meta_fp: Union[str, Path], ipath: Union[str, Iro
 
     Examples
     --------
-    >>> apply_meta_archive(session, "meta_archive.json", "/some/home/collection")
+    >>> apply_meta_archive("meta_archive.json", IrodsPath(session, "/some/home/collection"))
 
     """
-    ipath = IrodsPath(session, ipath)
+    session = ipath.session
     if not ipath.collection_exists():
         if ipath.dataobject_exists():
             raise NotACollectionError(f"Cannot apply metadata archive, since '{ipath}' "
@@ -499,6 +458,9 @@ def _param_checks(source, target):
 
     if isinstance(source, IrodsPath) and isinstance(target, IrodsPath):
         raise TypeError("iRODS to iRODS copying is not supported.")
+    
+    if (isinstance(source, Path) or isinstance(source, str)) and (isinstance(target, Path) or isinstance(target, str)):
+        raise TypeError("Local to local copying is not supported.")
 
 
 def _transfer_needed(source: Union[IrodsPath, Path],
@@ -519,7 +481,7 @@ def _transfer_needed(source: Union[IrodsPath, Path],
     if not overwrite:
         if not ignore_err:
             err_msg = (f"Cannot overwrite {source} -> {dest} unless overwrite==True. "
-                       f"To ignore this error and skip the files use ignore_err==True.")
+                       f"To ignore this error and skip the files use on_err=='warn' or 'skip'.")
             if isinstance(dest, IrodsPath):
                 raise DataObjectExistsError(err_msg)
             raise FileExistsError(err_msg)

--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -463,7 +463,7 @@ def apply_meta_archive(meta_fp: Union[str, Path], ipath: IrodsPath, dry_run: boo
 
 
 def _param_checks(source, target):
-    if not isinstance(source, IrodsPath) or not isinstance(target, IrodsPath):
+    if not isinstance(source, IrodsPath) and not isinstance(target, IrodsPath):
         raise TypeError("Either source or target should be an iRODS path.")
 
     if isinstance(source, IrodsPath) and isinstance(target, IrodsPath):

--- a/ibridges/data_operations.py
+++ b/ibridges/data_operations.py
@@ -24,7 +24,6 @@ from ibridges.exception import (
 )
 from ibridges.executor import Operations
 from ibridges.path import CachedIrodsPath, IrodsPath
-from ibridges.session import Session
 from ibridges.util import checksums_equal
 
 NUM_THREADS = 4
@@ -113,9 +112,9 @@ def upload(
         if not idest_path.collection_exists():
             ops.add_create_coll(idest_path)
         if not irods_path.collection_exists():
-            ops.add_create_coll(ipath)
+            ops.add_create_coll(irods_path)
     elif local_path.is_file():
-        idest_path = irods_path / local_path.name if irods_path.collection_exists() else ipath
+        idest_path = irods_path / local_path.name if irods_path.collection_exists() else irods_path
         obj_exists = idest_path.dataobject_exists()
         if not obj_exists or _transfer_needed(local_path, idest_path, overwrite, ignore_err):
             ops.add_upload(local_path, idest_path)
@@ -332,11 +331,14 @@ def sync(
                                      "can only sync collections.")
             raise CollectionDoesNotExistError(
                 f"Source collection '{source.absolute()}' does not exist")
-    else:
+    elif isinstance(target, IrodsPath):
         session = target.session
         if not Path(source).is_dir():
             raise NotADirectoryError(f"Source folder '{source}' is not a directory or "
                                      "does not exist.")
+
+    else:
+        raise TypeError("Either source or target must be an IrodsPath")
 
     if isinstance(source, IrodsPath):
         ops = _down_sync_operations(
@@ -345,7 +347,7 @@ def sync(
         )
     else:
         ops = _up_sync_operations(
-            Path(source), target, copy_empty_folders=copy_empty_folders,
+            Path(source), IrodsPath(session, target), copy_empty_folders=copy_empty_folders,
             depth=max_level, overwrite=True)
         if metadata is not None:
             ops.add_meta_upload(target, metadata)  # type: ignore
@@ -358,7 +360,7 @@ def sync(
     return ops
 
 
-def create_meta_archive(root_ipath: IrodsPath, meta_fp: Union[str, Path], dry_run: bool = False):
+def create_meta_archive(source: IrodsPath, meta_fp: Union[str, Path], dry_run: bool = False):
     """Create a local archive file for the metadata.
 
     The archive is a utf-8 encoded JSON file with the metadata of all subcollections
@@ -390,16 +392,16 @@ def create_meta_archive(root_ipath: IrodsPath, meta_fp: Union[str, Path], dry_ru
     >>> create_meta_archive(IrodsPath(session, "/some/home/collection"), "meta_archive.json")
 
     """
-    session = root_ipath.session
-    if not root_ipath.collection_exists():
-        if root_ipath.dataobject_exists():
+    session = source.session
+    if not source.collection_exists():
+        if source.dataobject_exists():
             raise NotACollectionError("Cannot download metadata archive: "
-                                 f"'{root_ipath}' is a data object, need a collection.")
+                                 f"'{source}' is a data object, need a collection.")
         raise CollectionDoesNotExistError("Cannot download metadata archive: "
-                                    f"'{root_ipath}' does not exist.")
+                                    f"'{source}' does not exist.")
     operations = Operations()
-    for ipath in root_ipath.walk():
-        operations.add_meta_download(root_ipath, ipath, meta_fp)
+    for ipath in source.walk():
+        operations.add_meta_download(source, ipath, meta_fp)
     if not dry_run:
         operations.execute(session)
     return operations
@@ -458,8 +460,8 @@ def _param_checks(source, target):
 
     if isinstance(source, IrodsPath) and isinstance(target, IrodsPath):
         raise TypeError("iRODS to iRODS copying is not supported.")
-    
-    if (isinstance(source, Path) or isinstance(source, str)) and (isinstance(target, Path) or isinstance(target, str)):
+
+    if isinstance(source, (str, Path)) and isinstance(target, (str, Path)):
         raise TypeError("Local to local copying is not supported.")
 
 
@@ -531,9 +533,9 @@ def _up_sync_operations(lsource_path: Path, idest_path: IrodsPath,  # pylint: di
         root_part = Path(root).relative_to(lsource_path)
         if depth is not None and len(root_part.parts) > depth:
             continue
-        root_ipath = idest_path.joinpath(*root_part.parts)
+        source = idest_path.joinpath(*root_part.parts)
         for cur_file in files:
-            ipath = root_ipath / cur_file
+            ipath = source / cur_file
             lpath = lsource_path / root_part / cur_file
 
             # Ignore symlinks
@@ -554,8 +556,8 @@ def _up_sync_operations(lsource_path: Path, idest_path: IrodsPath,  # pylint: di
                 if lpath.is_symlink():
                     warnings.warn(f"Ignoring symlink {lpath}.")
                     continue
-                if str(root_ipath / fold) not in remote_ipaths:
-                    operations.add_create_coll(root_ipath / fold)
-        if str(root_ipath) not in remote_ipaths:
-            operations.add_create_coll(root_ipath)
+                if str(source / fold) not in remote_ipaths:
+                    operations.add_create_coll(source / fold)
+        if str(source) not in remote_ipaths:
+            operations.add_create_coll(source)
     return operations

--- a/ibridges/executor.py
+++ b/ibridges/executor.py
@@ -293,7 +293,8 @@ class Operations():  # pylint: disable=too-many-instance-attributes
 
         """
         for col in self.create_collection:
-            IrodsPath.create_collection(session, col)
+            cpath = IrodsPath(session, col)
+            cpath.create_collection()
 
     def print_summary(self):
         """Print a summary of all the operations added to the object."""

--- a/ibridges/icat_columns.py
+++ b/ibridges/icat_columns.py
@@ -21,7 +21,7 @@ RESC_NAME = imodels.Resource.name
 RESC_PARENT = imodels.Resource.parent
 RESC_STATUS = imodels.Resource.status
 RESC_CONTEXT = imodels.Resource.context
-USER_GROUP_NAME = imodels.UserGroup.name
+USER_GROUP_NAME = imodels.Group.name
 USER_NAME = imodels.User.name
 USER_TYPE = imodels.User.type
 

--- a/ibridges/interactive.py
+++ b/ibridges/interactive.py
@@ -91,7 +91,6 @@ def _from_pw_file(irods_env_path, irodsa_backup: Optional[str] = None, **kwargs)
     except IndexError:
         print("INFO: The cached password in ~/.irods/.irodsA has been corrupted")
     except PasswordError:
-        print(irodsa_backup)
         if irodsa_backup is not None:
             with open(DEFAULT_IRODSA_PATH, "w", encoding="utf-8") as handle:
                 handle.write(irodsa_backup)

--- a/ibridges/meta.py
+++ b/ibridges/meta.py
@@ -157,7 +157,8 @@ class MetaData:
             )
         return all_items[0]
 
-    def __setitem__(self, key: Union[str, Sequence[Union[str, None]]], other: Sequence[str]):
+    def __setitem__(self, key: Union[str, Sequence[str]],
+                    other: Union[str, Sequence[str], Sequence[Sequence[str]]]):
         """Set metadata items like a dictionary of tuples.
 
         Parameters
@@ -176,26 +177,49 @@ class MetaData:
 
         Examples
         --------
-        >>> meta["key"] = ("key", "new_value", "new_units")
-        >>> meta["key"] = ("new_key", "old_value")
+        >>> meta["key"] = "values"
+        >>> meta["key"] = "values", "units"
+        >>> meta["key", "value"] = "units"
 
         """
         if isinstance(other, str):
-            raise TypeError(
-                "Cannot set the metadata item to a single string value. "
-                f'Use meta[{key}].key = "{other}" to change only the key '
-                "for example."
-            )
-        self[key].update(*other)
+            other = [other]
+        if isinstance(key, str):
+            key = [key]
+
+        if len(key) > 2:
+            raise ValueError("Use either one or two values within the brackets [], for example "
+                             f"meta['some_key', 'some_value'] = 'some_units', got: {key}")
+
+        all_items = self.find_all(*key)
+        if all(isinstance(o, str) for o in other):
+            if len(all_items) > 1:
+                raise ValueError(f"Cannot set item with '{key}' to single item: multiple entries"
+                                 f" exist. Use meta[{key}] = [{other}] to remove all current values"
+                                 f" with new values.")
+            other = [other]  # type: ignore
+        for subset in other:
+            if not all(isinstance(s, str) for s in subset):
+                raise ValueError(
+                    "Badly formed argument to __setitem__: should be set to either string,"
+                    " list of strings or list of list of strings.")
+            if len(subset) + len(key) > 3:
+                raise ValueError(
+                    f"Too many items to create metadata triple {subset} + {key}. Use "
+                    "meta['key'] = 'value', 'units' or meta['key', 'value'] = 'units'.")
+
+        for item in all_items:
+            item.remove()
+
+        for sub in other:
+            self.add(*key, *sub)
 
     def add(self, key: str, value: str, units: Optional[str] = ""):
         """Add metadata to an item.
 
         This will never overwrite an existing entry. If the triplet already exists
         it will throw an error instead. Note that entries are only considered the same
-        if all of the key, value and units are the same. Alternatively you can use the
-        :meth:`set` method to remove all entries with the same key, before adding the
-        new entry.
+        if all of the key, value and units are the same.
 
         Parameters
         ----------
@@ -241,6 +265,9 @@ class MetaData:
         the same key will be deleted before adding the new entry. An alternative
         is using the :meth:`add` method to only add to the metadata entries and not
         delete them.
+
+        This method is deprecated, and will be removed in the future. You should use
+        the bracket [] notation instead: meta[key] = value or meta[key] = value, units.
 
         Parameters
         ----------
@@ -490,7 +517,7 @@ class MetaDataItem:
         yield self.value
         yield self.units
 
-    def update(self, new_key: str, new_value: str, new_units: Optional[str] = ""):
+    def update(self, new_key: str, new_value: str, new_units: str = ""):
         """Update the metadata item changing the key/value/units.
 
         Parameters

--- a/ibridges/path.py
+++ b/ibridges/path.py
@@ -203,7 +203,6 @@ class IrodsPath:
         except irods.exception.CUT_ACTION_PROCESSED_ERR as exc:
             raise PermissionError(f"While removing {self}: iRODS server forbids action.") from exc
 
-    @staticmethod
     def create_collection(
         session, coll_path: Union[IrodsPath, str]
     ) -> irods.collection.iRODSCollection:

--- a/ibridges/path.py
+++ b/ibridges/path.py
@@ -203,17 +203,8 @@ class IrodsPath:
         except irods.exception.CUT_ACTION_PROCESSED_ERR as exc:
             raise PermissionError(f"While removing {self}: iRODS server forbids action.") from exc
 
-    def create_collection(
-        session, coll_path: Union[IrodsPath, str]
-    ) -> irods.collection.iRODSCollection:
+    def create_collection(self) -> irods.collection.iRODSCollection:
         """Create a collection and all parent collections that do not exist yet.
-
-        Parameters
-        ----------
-        session:
-            Session for which the collection is created.
-        coll_path:
-            Irods path to the collection to be created.
 
         Raises
         ------
@@ -227,18 +218,26 @@ class IrodsPath:
 
         Examples
         --------
-        >>> IrodsPath.create_collection(session, "/zone/home/user/some_collection")
-        >>> IrodsPath.create_collection(session, IrodsPath(session, "~/some_collection"))
+        >>> new_collection = IrodsPath(session, "/zone/home/user/some_collection")
+        >>> new_collection.create_collection()
+        >>> new_collection = session, IrodsPath(session, "~/some_collection"))
+        >>> new_collection.create_collection()
 
         """
+        #args = [a._path if isinstance(a, IrodsPath) else a for a in args]
         try:
-            return session.irods_session.collections.create(str(coll_path))
-        except irods.exception.CAT_NO_ACCESS_PERMISSION as error:
-            raise PermissionError(f"Cannot create {str(coll_path)}, no access.") from error
-        except irods.exception.CUT_ACTION_PROCESSED_ERR as exc:
+            return self.session.irods_session.collections.create(str(self.absolute()))
+        except irods.exception.CAT_NO_ACCESS_PERMISSION as e:
+            raise PermissionError(f"Cannot create {str(self)}, no access.") from e
+        except irods.exception.CUT_ACTION_PROCESSED_ERR as e:
             raise PermissionError(
-                "While creating collection '{coll_path}': iRODS server forbids action."
-            ) from exc
+                f"While creating collection '{str(self)}': iRODS server forbids action."
+            ) from e
+        except irods.exception.USER_INPUT_PATH_ERR as e:
+            raise ValueError("No collection path given.") from e
+        except irods.exception.SYS_INVALID_INPUT_PARAM as e:
+            msg = f"Zone {self._path.parts[1]} not found. Use: {self.session.zone}."
+            raise ValueError(msg) from e
 
     def rename(self, new_name: Union[str, IrodsPath]) -> IrodsPath:
         """Change the name or the path of a data object or collection.
@@ -269,15 +268,12 @@ class IrodsPath:
             raise DoesNotExistError(f"{str(self)} does not exist.")
 
         # Build new path
-        if str(new_name).startswith("/" + self.session.zone):
-            new_path = IrodsPath(self.session, new_name)
-        else:
-            new_path = self.parent.joinpath(new_name)
+        new_path = IrodsPath(self.session, new_name)
 
         try:
             # Make sure new path exists on iRODS server
             if not new_path.parent.exists():
-                self.create_collection(self.session, new_path.parent)
+                new_path.parent.create_collection()
 
             if self.dataobject_exists():
                 self.session.irods_session.data_objects.move(str(self), str(new_path))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ classifiers = [
 ]
 
 dependencies = [
-    "python-irodsclient>=2.0.0, !=3.1.0",
+    "python-irodsclient>=2.0.0, !=3.1.0;python_version>='3.9'",
+    "python-irodsclient>=2.0.0, !=3.1.0, <3.2;python_version<'3.9'",
     "tqdm",
     "importlib-metadata>=4.6;python_version<'3.10'",
 ]

--- a/tutorials/02-iRODS-paths.ipynb
+++ b/tutorials/02-iRODS-paths.ipynb
@@ -346,7 +346,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "IrodsPath.create_collection(session, irods_path)"
+    "irods_path.create_collection()"
    ]
   },
   {
@@ -521,7 +521,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "out = IrodsPath.create_collection(session, irods_path)\n",
+    "out = irods_path.create_collection()\n",
     "print(out)"
    ]
   },

--- a/tutorials/03-Working-with-data.ipynb
+++ b/tutorials/03-Working-with-data.ipynb
@@ -69,12 +69,12 @@
    "outputs": [],
    "source": [
     "from ibridges.path import IrodsPath\n",
-    "from ibridges.data_operations import create_collection\n",
+    "\n",
     "irods_path = IrodsPath(session, '~')\n",
     "print(\"Current working location:\", irods_path)\n",
     "coll_path = irods_path.joinpath('demo')\n",
     "print(\"New collection name:\", coll_path)\n",
-    "coll = create_collection(session, coll_path)\n",
+    "coll_path.create_collection()\n",
     "print(\"New collection is created:\", coll_path.collection_exists())"
    ]
   },
@@ -122,7 +122,7 @@
    "outputs": [],
    "source": [
     "from ibridges import upload\n",
-    "ops = upload(session, local_file, coll_path, overwrite=True)"
+    "ops = upload(local_file, coll_path, overwrite=True)"
    ]
   },
   {
@@ -212,7 +212,8 @@
    "outputs": [],
    "source": [
     "from ibridges import download\n",
-    "ops = download(session, coll_path.joinpath('demofile.txt'), local_path, dry_run=True, overwrite=True)"
+    "ops = download(coll_path.joinpath('demofile.txt'), local_path, dry_run=True, overwrite=True)\n",
+    "ops.print_summary()"
    ]
   },
   {
@@ -230,7 +231,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ops = download(session, coll_path.joinpath('demofile.txt'), local_path)"
+    "ops = download(coll_path.joinpath('demofile.txt'), local_path)"
    ]
   },
   {
@@ -248,7 +249,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "download(session, coll_path.joinpath('demofile.txt'), local_path)"
+    "download(coll_path.joinpath('demofile.txt'), local_path)"
    ]
   },
   {
@@ -256,7 +257,7 @@
    "id": "13e5c96d",
    "metadata": {},
    "source": [
-    "You will receive an Exception `OVERWRITE_WITHOUT_FORCE_FLAG`. This means that the file is already there.  \n",
+    "You will receive an Exception `FileExistsError`. This means that the file is already there.  \n",
     "\n",
     "**Note, both the upload and the download function do not overwrite existing data by default.** \n",
     "\n",
@@ -270,7 +271,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ops = download(session, coll_path.joinpath('demofile.txt'), local_path, overwrite=True)"
+    "ops = download(coll_path.joinpath('demofile.txt'), local_path, overwrite=True)"
    ]
   },
   {
@@ -304,7 +305,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ops = download(session, coll_path.joinpath('demofile.txt'), local_path, dry_run=True, overwrite=True)\n",
+    "ops = download(coll_path.joinpath('demofile.txt'), local_path, dry_run=True, overwrite=True)\n",
     "ops.print_summary()"
    ]
   },
@@ -403,8 +404,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print('Data object size', obj.size)\n",
-    "print('Data object checksum', obj.checksum)"
+    "print('Data object size', obj_path.size)\n",
+    "print('Data object checksum', obj_path.checksum)"
    ]
   },
   {
@@ -436,7 +437,7 @@
     "\n",
     "<img src=\"img/DataObject3.png\" width=\"400\">\n",
     "\n",
-    "Let us inspect how many replicas of our file we have in iRODS:"
+    "Let us inspect how many replicas of our file we have in iRODS. We need to get the real iRODS object behind the path:"
    ]
   },
   {
@@ -446,8 +447,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from ibridges.data_operations import obj_replicas\n",
-    "obj_replicas(obj)"
+    "from ibridges.util import obj_replicas\n",
+    "obj_replicas(obj_path.dataobject)"
    ]
   },
   {
@@ -467,7 +468,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "item = obj_replicas(obj)[0]\n",
+    "item = obj_replicas(obj_path.dataobject)[0]\n",
     "print('Relplica index:', item[0])\n",
     "print('Storage system:', item[1])\n",
     "print('Replica cecksum', item[2])\n",
@@ -508,7 +509,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,

--- a/tutorials/04-Metadata.ipynb
+++ b/tutorials/04-Metadata.ipynb
@@ -314,7 +314,7 @@
    "id": "5dbc03e9-3b30-4b0d-9b7c-f3be1403bf75",
    "metadata": {},
    "source": [
-    "Another way to set a metadata key to a new value and units is the `set` function."
+    "Another way to set a metadata key to a new value and units is with the bracket `[]` notation."
    ]
   },
   {
@@ -334,7 +334,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "obj_meta.set('Author', 'person')\n",
+    "obj_meta['Author'] = 'person'\n",
     "print(obj_meta)"
    ]
   },
@@ -353,7 +353,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "obj_meta.set('Key', 'OtherValue')\n",
+    "obj_meta['Key'] = 'OtherValue'\n",
     "print(obj_meta)"
    ]
   },
@@ -900,7 +900,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -914,7 +914,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.4"
+   "version": "3.11.6"
   }
  },
  "nbformat": 4,

--- a/tutorials/06-Data-sync.ipynb
+++ b/tutorials/06-Data-sync.ipynb
@@ -130,7 +130,6 @@
    "outputs": [],
    "source": [
     "ops = sync(\n",
-    "    session=session,\n",
     "    source=source,\n",
     "    target=target,\n",
     "    max_level=max_level,      \n",
@@ -166,7 +165,6 @@
    "outputs": [],
    "source": [
     "ops = sync(\n",
-    "    session=session,\n",
     "    source=source,\n",
     "    target=target,\n",
     "    max_level=max_level,      \n",
@@ -199,7 +197,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.13.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Also removes the function `create_collection` from the data_operations in favour of the `IrodsPath.create_collection`.

Depends on #334 being merged first.

Fixes #340 and fixes #339 