### PR TITLE
Tree ls colors

### DIFF
--- a/docker/irods_client/tests/test_cli.py
+++ b/docker/irods_client/tests/test_cli.py
@@ -135,7 +135,7 @@ def test_list_cli(config, pass_opts, irods_env_file, collection):
     subprocess.run(["ibridges", "init", irods_env_file], **pass_opts)
     subprocess.run(["ibridges", "list"], **pass_opts)
     subprocess.run(["ibridges", "list", f"irods:{collection.path}"], **pass_opts)
-    subprocess.run(["ibridges", "list", "-s"], **pass_opts)
+    subprocess.run(["ibridges", "list", "-i"], **pass_opts)
     subprocess.run(["ibridges", "list", "-l"], **pass_opts)
 
 

--- a/docs/source/ibridges_cli.rst
+++ b/docs/source/ibridges_cli.rst
@@ -474,3 +474,13 @@ with :code:`{new_command}`.
 Since this feature is relatively new, there are currently no plugins available, but an example can be found on
 `GitHub <https://github.com/iBridges-for-iRODS/ibridges-cli-plugin-example>`__. If you have created a plugin that
 has general use, contact and we will list it here.
+
+Color Customisation
+-------------------
+
+The command `ibridges tree` highlights the iRODS collections by default in blue. It uses the Linux `LS_COLORS` which are set
+when you choose your terminal colors. On Mac can alter that by this color with
+.. code:: shell
+	LS_COLORS=$LS_COLORS:'di=1;44:' ; export LS_COLORS
+
+Please have a look [here](https://gist.github.com/thomd/7667642#ls_colors) for possible color and highlighting settings.

--- a/docs/source/ibridges_cli.rst
+++ b/docs/source/ibridges_cli.rst
@@ -475,12 +475,13 @@ Since this feature is relatively new, there are currently no plugins available, 
 `GitHub <https://github.com/iBridges-for-iRODS/ibridges-cli-plugin-example>`__. If you have created a plugin that
 has general use, contact and we will list it here.
 
-Color Customisation
+Color Customization
 -------------------
 
 The command `ibridges tree` highlights the iRODS collections by default in blue. It uses the Linux `LS_COLORS` which are set
 when you choose your terminal colors. On Mac can alter that by this color with
 .. code:: shell
+
 	LS_COLORS=$LS_COLORS:'di=1;44:' ; export LS_COLORS
 
 Please have a look [here](https://gist.github.com/thomd/7667642#ls_colors) for possible color and highlighting settings.

--- a/ibridges/cli/navigation.py
+++ b/ibridges/cli/navigation.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import argparse
 import os
-from typing import Optional
 import platform
+from typing import Optional
 
 from ibridges.cli.base import BaseCliCommand
 from ibridges.cli.config import IbridgesConf

--- a/ibridges/cli/navigation.py
+++ b/ibridges/cli/navigation.py
@@ -243,7 +243,7 @@ class CliTree(BaseCliCommand):
     def run_shell(session, parser, args):
         """Show the tree of a collection."""
         ipath = IrodsPath(session, args.remote_coll)
-        ls_colors = os.environ.get("LS_COLORZ", "")
+        ls_colors = os.environ.get("LS_COLORS", "")
         dir_color = [x for x in ls_colors.split(":") if x.startswith("di=")]
         dir_color = None if len(dir_color) == 0 else dir_color[0][3:]
         if not ipath.collection_exists():

--- a/ibridges/cli/navigation.py
+++ b/ibridges/cli/navigation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import os
+from sys import platform
 from typing import Optional
 
 from ibridges.cli.base import BaseCliCommand
@@ -192,8 +193,10 @@ def _tree(
                 dir_color=dir_color,
             )
             continue
-        if dir_color is None or cur_path.dataobject_exists():
+        if cur_path.dataobject_exists():
             str_path = str(rel_path)
+        elif dir_color is None: # use default blue
+            str_path = "\033[34m" + str(rel_path) + "\033[0m"
         else:
             str_path = f"\033[{dir_color}m" + str(rel_path) + "\033[0m"
         build_list.append(str_path)
@@ -246,6 +249,7 @@ class CliTree(BaseCliCommand):
         ls_colors = os.environ.get("LS_COLORS", "")
         dir_color = [x for x in ls_colors.split(":") if x.startswith("di=")]
         dir_color = None if len(dir_color) == 0 else dir_color[0][3:]
+        
         if not ipath.collection_exists():
             parser.error(f"{ipath} is not a collection.")
             return

--- a/ibridges/cli/navigation.py
+++ b/ibridges/cli/navigation.py
@@ -348,11 +348,11 @@ def _check_dir_color(session):
 
     if platform.system() == "Windows":
         try:
-            import ctypes
+            import ctypes  # pylint: disable=import-outside-toplevel
             kernel32 = ctypes.windll.kernel32
             kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)
             dir_color = "34"
-        except Exception:
+        except Exception:  # pylint: disable=broad-exception-caught
             dir_color = None
     else:
         ls_colors = os.environ.get("LS_COLORS", "")

--- a/ibridges/cli/navigation.py
+++ b/ibridges/cli/navigation.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import argparse
 import os
-from sys import platform
 from typing import Optional
 
 from ibridges.cli.base import BaseCliCommand
@@ -249,7 +248,7 @@ class CliTree(BaseCliCommand):
         ls_colors = os.environ.get("LS_COLORS", "")
         dir_color = [x for x in ls_colors.split(":") if x.startswith("di=")]
         dir_color = None if len(dir_color) == 0 else dir_color[0][3:]
-        
+
         if not ipath.collection_exists():
             parser.error(f"{ipath} is not a collection.")
             return

--- a/ibridges/cli/navigation.py
+++ b/ibridges/cli/navigation.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import os
 from typing import Optional
+import platform
 
 from ibridges.cli.base import BaseCliCommand
 from ibridges.cli.config import IbridgesConf
@@ -33,12 +34,12 @@ class CliList(BaseCliCommand):
         )
         parser.add_argument(
             "-m", "--metadata",
-            help="Show metadata for each iRODS location.",
+            help="Show metadata for each iRODS location, only in combination with -i/--icommands.",
             action="store_true",
         )
         parser.add_argument(
-            "-s", "--short",
-            help="Display available data objects/collections in short form.",
+            "-i", "--icommands",
+            help="Display available data objects/collections in iCommands form.",
             action="store_true"
         )
         parser.add_argument(
@@ -46,23 +47,31 @@ class CliList(BaseCliCommand):
             help="Display available data objects/collections in long form.",
             action="store_true",
         )
+        parser.add_argument(
+            "--nocolor",
+            help="Disable printing with color.",
+            action="store_true",
+        )
         return parser
 
     @staticmethod
     def run_shell(session, parser, args):
         """List a collection on an iRODS server."""
-        ipath =  parse_remote(args.remote_coll, session)
+        ipath = parse_remote(args.remote_coll, session)
+        dir_color = None if args.nocolor else _check_dir_color(session)
         try:
             if args.long:
                 for cur_path in ipath.walk(depth=1, include_base_collection=False):
                     if cur_path.collection_exists():
-                        print(f"C- {cur_path.name}")
+                        print(f"{64*' '}{_path_with_color(cur_path, dir_color)}")
                     else:
                         print(f"{cur_path.checksum: <50} {cur_path.size: <12} {cur_path.name}")
-            elif args.short:
-                print(" ".join([x.name for x in ipath.walk(depth=1) if str(x) != str(ipath)]))
-            else:
+            elif args.icommands:
                 list_collection(session, ipath, args.metadata)
+
+            else:
+                print(" ".join([_path_with_color(x, dir_color) for x in ipath.walk(depth=1)
+                                if str(x) != str(ipath)]))
         except NotACollectionError:
             parser.error(f"{ipath} is not a collection")
 
@@ -192,15 +201,14 @@ def _tree(
                 dir_color=dir_color,
             )
             continue
-        if cur_path.dataobject_exists():
-            str_path = str(rel_path)
-        elif dir_color is None: # use default blue
-            str_path = "\033[34m" + str(rel_path) + "\033[0m"
-        else:
-            str_path = f"\033[{dir_color}m" + str(rel_path) + "\033[0m"
+        str_path = _path_with_color(cur_path, dir_color)
+        # if cur_path.dataobject_exists() or dir_color is None:
+            # str_path = str(rel_path)
+        # else:
+            # str_path = f"\033[{dir_color}m" + str(rel_path) + "\033[0m"
         build_list.append(str_path)
         j_path += 1
-    _print_build_list(build_list, prefix, show_max=show_max, pels=pels, )
+    _print_build_list(build_list, prefix, show_max=show_max, pels=pels)
     return j_path
 
 
@@ -245,9 +253,7 @@ class CliTree(BaseCliCommand):
     def run_shell(session, parser, args):
         """Show the tree of a collection."""
         ipath = IrodsPath(session, args.remote_coll)
-        ls_colors = os.environ.get("LS_COLORS", "")
-        dir_color = [x for x in ls_colors.split(":") if x.startswith("di=")]
-        dir_color = None if len(dir_color) == 0 else dir_color[0][3:]
+        dir_color = _check_dir_color(session)
 
         if not ipath.collection_exists():
             parser.error(f"{ipath} is not a collection.")
@@ -335,3 +341,30 @@ class CliSearch(BaseCliCommand):
         )
         for cur_path in search_res:
             print(cur_path)
+
+def _check_dir_color(session):
+    if hasattr(session, "dir_color"):
+        return getattr(session, "dir_color")
+
+    if platform.system() == "Windows":
+        try:
+            import ctypes
+            kernel32 = ctypes.windll.kernel32
+            kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)
+            dir_color = "34"
+        except Exception:
+            dir_color = None
+    else:
+        ls_colors = os.environ.get("LS_COLORS", "")
+        dir_color = [x for x in ls_colors.split(":") if x.startswith("di=")]
+        dir_color = "34" if len(dir_color) == 0 else dir_color[0][3:]
+
+    session.dir_color = dir_color
+    return dir_color
+
+def _path_with_color(path, dir_color):
+    if path.dataobject_exists() or dir_color is None:
+        str_path = str(path.name)
+    else:
+        str_path = f"\033[{dir_color}m" + str(path.name) + "\033[0m"
+    return str_path

--- a/ibridges/cli/navigation.py
+++ b/ibridges/cli/navigation.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import argparse
+import os
+from typing import Optional
 
 from ibridges.cli.base import BaseCliCommand
 from ibridges.cli.config import IbridgesConf
@@ -162,6 +164,7 @@ def _tree(
     pels: dict[str, str],
     prefix: str = "",
     show_max: int = 10,
+    dir_color: Optional[str] = None,
 ):
     """Generate A recursive generator, given a directory Path object.
 
@@ -186,11 +189,16 @@ def _tree(
                 show_max=show_max,
                 prefix=prefix + pels["branch"],
                 pels=pels,
+                dir_color=dir_color,
             )
             continue
-        build_list.append(str(rel_path))
+        if dir_color is None or cur_path.dataobject_exists():
+            str_path = str(rel_path)
+        else:
+            str_path = f"\033[{dir_color}m" + str(rel_path) + "\033[0m"
+        build_list.append(str_path)
         j_path += 1
-    _print_build_list(build_list, prefix, show_max=show_max, pels=pels)
+    _print_build_list(build_list, prefix, show_max=show_max, pels=pels, )
     return j_path
 
 
@@ -235,6 +243,9 @@ class CliTree(BaseCliCommand):
     def run_shell(session, parser, args):
         """Show the tree of a collection."""
         ipath = IrodsPath(session, args.remote_coll)
+        ls_colors = os.environ.get("LS_COLORZ", "")
+        dir_color = [x for x in ls_colors.split(":") if x.startswith("di=")]
+        dir_color = None if len(dir_color) == 0 else dir_color[0][3:]
         if not ipath.collection_exists():
             parser.error(f"{ipath} is not a collection.")
             return
@@ -244,7 +255,7 @@ class CliTree(BaseCliCommand):
             pels = _tree_elements["pretty"]
         ipath_list = [cur_path for cur_path in ipath.walk(depth=args.depth)
                       if str(cur_path) != str(ipath)]
-        _tree(ipath, ipath_list, show_max=args.show_max, pels=pels)
+        _tree(ipath, ipath_list, show_max=args.show_max, pels=pels, dir_color=dir_color)
         n_col = sum(cur_path.collection_exists() for cur_path in ipath_list)
         n_data = len(ipath_list) - n_col
         print_str = f"\n{n_col} collections, {n_data} data objects"


### PR DESCRIPTION
Fixes #317 

The `ibridges tree` command now will automatically try to pick the directory color from your LS_COLORS if it is setup.