### PR TITLE
Hot fix to exclude the latest PRC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "python-irodsclient>=2.0.0, !=3.1.0",
+    "python-irodsclient>=2.0.0, !=3.1.0, <3.2.0",
     "tqdm",
     "importlib-metadata>=4.6;python_version<'3.10'",
 ]


### PR DESCRIPTION
PRC 3.2.0 is breaking the current release.
This is a hotfix for this iBridges version so that people who are installing iBridges for the first time and from the current release will have a working setup.

The permanent fix is already ready in develop #350 