### PR TITLE
Use /zone/home as irods_home

### DIFF
--- a/ibridges/session.py
+++ b/ibridges/session.py
@@ -102,7 +102,11 @@ class Session:  # pylint: disable=too-many-instance-attributes
         if irods_home is not None:
             self.home = irods_home
         if "irods_home" not in self._irods_env:
-            self.home = "/" + self.zone + "/home/" + self.username
+            irods_base = "/" + self.zone
+            if self.session.irods_session.collections.exists(irods_base):
+                self.home = irods_base
+            else:
+                self.home = "/" + self.zone + "/home/" + self.username
 
         self._cwd = self.home
         if cwd is not None:

--- a/ibridges/session.py
+++ b/ibridges/session.py
@@ -102,7 +102,7 @@ class Session:  # pylint: disable=too-many-instance-attributes
         if irods_home is not None:
             self.home = irods_home
         if "irods_home" not in self._irods_env:
-            irods_base = "/" + self.zone
+            irods_base = "/" + self.zone + "/home"
             if self.session.irods_session.collections.exists(irods_base):
                 self.home = irods_base
             else:


### PR DESCRIPTION
If users do not define an irods_home in the environment file, there are two options to default to.
If users have access to `/zone/home` then default to that path, else default to `/zone/home/user`.