### PR TITLE
FAQ - add examples how to list data outside of your home

### DIFF
--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -106,8 +106,8 @@ You can omit this by the following code:
     meta = MetaData(IrodsPath(session, "~", "my_obj").dataobject, blacklist=None)
     print(meta)
 
-**How can I list all data I have access to?**
----------------------------------------------
+**How can I list all data I have access to but which does not lie in my home or standard collection?**
+--------------------------------------------------------------------------------------------------------
 When data is shared in iRODS it is not always easy to know where the shared data lies. With the CLI search you can list all data you have access to and then use `grep` to filter or ignore (`-v` option) certain results. Below we show an example to list all collections you have access to outside of your home-collection:
 
 .. code-block:: bash

--- a/docs/source/faq.rst
+++ b/docs/source/faq.rst
@@ -105,3 +105,31 @@ You can omit this by the following code:
     # data objects
     meta = MetaData(IrodsPath(session, "~", "my_obj").dataobject, blacklist=None)
     print(meta)
+
+**How can I list all data I have access to?**
+---------------------------------------------
+When data is shared in iRODS it is not always easy to know where the shared data lies. With the CLI search you can list all data you have access to and then use `grep` to filter or ignore (`-v` option) certain results. Below we show an example to list all collections you have access to outside of your home-collection:
+
+.. code-block:: bash
+
+    ibridges search /tempZone/home --item_type collection --path-pattern "%" | grep -v "/tempZone/home/<your_user_name>"
+
+In Python the code to retrieve all collections which are not in your `irods_home` would look like this:
+
+.. code-block:: python
+
+    from ibridges.interactive import interactive_auth
+    from ibridges import search_data, IrodsPath
+
+    session = interactive_auth()
+    search_res = search_data(session, path="/tempZone/home",  item_type="collection", path_pattern="%")
+
+    home_path = IrodsPath(session, session.home)
+    not_relative = []
+
+    for res in search_res:
+        try:
+            res.relative_to(home_path)   # succeeds only if res is inside home_path
+        except ValueError:
+            not_relative.append(res)
+

--- a/ibridges/cli/navigation.py
+++ b/ibridges/cli/navigation.py
@@ -306,7 +306,7 @@ class CliSearch(BaseCliCommand):
     def _mod_parser(cls, parser):
         parser.add_argument(
             "remote_path",
-            help="Remote path to search inn. The path itself will not be matched.",
+            help="Remote path to search in. The path itself will not be matched.",
             type=str,
             default=".",
             nargs="?",
@@ -319,7 +319,7 @@ class CliSearch(BaseCliCommand):
                 "Pattern of the path constraint. For example, use '%%.txt' "
                 "to find all data objects"
                 " and collections that end with .txt. You can also use the name of the item here "
-                "to find all items with that name."
+                "to find all items with that name. To find all data use '%'."
             ),
         )
         parser.add_argument(


### PR DESCRIPTION
Some data cannot directly be accessed from the users home or from another upstream collection, e.g. when only a subcollection is shared. Then you cannot navigate with the list or walk to that data.
I extended the FAQ how to find such data with the CLI and some python code.