### PR TITLE
Add authentication without interactive elements

### DIFF
--- a/ibridges/authenticate.py
+++ b/ibridges/authenticate.py
@@ -8,7 +8,7 @@ from typing import Optional, Union
 
 from ibridges.cli.config import IbridgesConf
 from ibridges.session import LoginError, PasswordError, Session
-from ibridges.util import ValueErrorParser, open_irodsa, DEFAULT_IRODSA_PATH, DEFAULT_IENV_PATH
+from ibridges.util import DEFAULT_IENV_PATH, DEFAULT_IRODSA_PATH, ValueErrorParser, open_irodsa
 
 
 def cli_auth(parser, reauthenticate: bool = False):

--- a/ibridges/authenticate.py
+++ b/ibridges/authenticate.py
@@ -13,6 +13,7 @@ from ibridges.util import DEFAULT_IENV_PATH, DEFAULT_IRODSA_PATH, ValueErrorPars
 
 def cli_auth(parser, reauthenticate: bool = False):
     """Authenticate for the CLI and shell."""
+    print(reauthenticate)
     ibridges_conf = IbridgesConf(parser)
     ienv_path, ienv_entry = ibridges_conf.get_entry()
     ienv_cwd = ienv_entry.get("cwd", None)
@@ -21,7 +22,7 @@ def cli_auth(parser, reauthenticate: bool = False):
         parser.error(f"Error: Irods environment file or alias '{ienv_path}' does not exist.")
     irodsa_backup = None if reauthenticate else ienv_entry.get("irodsa_backup", None)
     session = interactive_auth(irods_env_path=ienv_path, cwd=ienv_cwd,
-                               irodsa_backup=irodsa_backup)
+                               irodsa_backup=irodsa_backup, reauthenticate=reauthenticate)
 
     with open_irodsa(DEFAULT_IRODSA_PATH, "r", encoding="utf-8") as handle:
         irodsa_content = handle.read()
@@ -79,7 +80,7 @@ def non_interactive_auth(*args, ienv_path_or_alias: Optional[str] = None,
 
 def interactive_auth(
     password: Optional[str] = None, irods_env_path: Union[None, str, Path] = None,
-    irodsa_backup: Optional[str] = None,
+    irodsa_backup: Optional[str] = None, reauthenticate: bool = False,
     **kwargs
 ) -> Session:
     """Interactive authentication with iRODS server.
@@ -119,7 +120,7 @@ def interactive_auth(
         raise FileNotFoundError
 
     session = None
-    if DEFAULT_IRODSA_PATH.is_file() and password is None:
+    if DEFAULT_IRODSA_PATH.is_file() and password is None and not reauthenticate:
         session = _from_pw_file(irods_env_path, irodsa_backup=irodsa_backup, **kwargs)
 
     if password is not None:

--- a/ibridges/authenticate.py
+++ b/ibridges/authenticate.py
@@ -13,7 +13,6 @@ from ibridges.util import DEFAULT_IENV_PATH, DEFAULT_IRODSA_PATH, ValueErrorPars
 
 def cli_auth(parser, reauthenticate: bool = False):
     """Authenticate for the CLI and shell."""
-    print(reauthenticate)
     ibridges_conf = IbridgesConf(parser)
     ienv_path, ienv_entry = ibridges_conf.get_entry()
     ienv_cwd = ienv_entry.get("cwd", None)
@@ -52,9 +51,6 @@ def non_interactive_auth(*args, ienv_path_or_alias: Optional[str] = None,
     parser:
         Parser to relay the error messages to. By default, errors are raised as
         ValueError's.
-    reauthenticate:
-        If reauthenticate is set to True, then cached passwords will be ignored and a new password
-        can be submitted.
     kwargs:
         Extra keyword arguments for the session such as home and password.
 
@@ -102,6 +98,9 @@ def interactive_auth(
         Path to the irods environment.
     irodsa_backup:
         Backup of the .irodsA file to be used in case authentication fails.
+    reauthenticate:
+        If reauthenticate is set to True, then cached passwords will be ignored and a new password
+        can be submitted.
     kwargs:
         Extra parameters for the interactive auth. Mainly used for the cwd parameter.
 

--- a/ibridges/authenticate.py
+++ b/ibridges/authenticate.py
@@ -72,7 +72,7 @@ def non_interactive_auth(*args, ienv_path_or_alias: Optional[str] = None,
                 handle.write(irodsa_backup)
     except KeyError:
         ienv_path = ienv_path_or_alias
-        cwd = cwd
+        cwd_final = cwd
 
     return Session(ienv_path, *args, **kwargs, cwd=cwd_final)
 

--- a/ibridges/authenticate.py
+++ b/ibridges/authenticate.py
@@ -1,0 +1,177 @@
+"""Authentication with iRODS server."""
+
+import os
+import sys
+from getpass import getpass
+from pathlib import Path
+from typing import Optional, Union
+
+from ibridges.cli.config import IbridgesConf
+from ibridges.session import LoginError, PasswordError, Session
+from ibridges.util import ValueErrorParser, open_irodsa, DEFAULT_IRODSA_PATH, DEFAULT_IENV_PATH
+
+
+def cli_auth(parser, reauthenticate: bool = False):
+    """Authenticate for the CLI and shell."""
+    ibridges_conf = IbridgesConf(parser)
+    ienv_path, ienv_entry = ibridges_conf.get_entry()
+    ienv_cwd = ienv_entry.get("cwd", None)
+
+    if not Path(ienv_path).exists():
+        parser.error(f"Error: Irods environment file or alias '{ienv_path}' does not exist.")
+    irodsa_backup = None if reauthenticate else ienv_entry.get("irodsa_backup", None)
+    session = interactive_auth(irods_env_path=ienv_path, cwd=ienv_cwd,
+                               irodsa_backup=irodsa_backup)
+
+    with open_irodsa(DEFAULT_IRODSA_PATH, "r", encoding="utf-8") as handle:
+        irodsa_content = handle.read()
+    if irodsa_content != ienv_entry.get("irodsa_backup"):
+        ienv_entry["irodsa_backup"] = irodsa_content
+        ibridges_conf.save()
+
+    return session
+
+
+def non_interactive_auth(*args, ienv_path_or_alias: Optional[str] = None,
+                         cwd: Optional[str] = None,
+                         parser=ValueErrorParser(), **kwargs):
+    """Non interactive authentication that doesn't ask for a password.
+
+    This authentication is integrated with the CLI configuration.
+
+    Parameters
+    ----------
+    args:
+        Extra arguments for the Session object.
+    ienv_path_or_alias:
+        alias or iRODS environment file to use for authentication. If None,
+        use the currently selected environment in the configuration file.
+    cwd:
+        Current working collection to set.
+    parser:
+        Parser to relay the error messages to. By default, errors are raised as
+        ValueError's.
+    kwargs:
+        Extra keyword arguments for the session such as home and password.
+
+    Returns
+    -------
+    session:
+        Session after successfully authenticating.
+
+    """
+    # iBridges doesn't have a non-interactive auth, so make one.
+    ibridges_conf = IbridgesConf(parser=parser)
+    try:
+        ienv_path, ienv_entry = ibridges_conf.get_entry(ienv_path_or_alias)
+        irodsa_backup = ienv_entry.get("irodsa_backup", None)
+        cwd_stored = ienv_entry.get("cwd", None)
+        cwd_final = cwd_stored if cwd is None else cwd
+        if irodsa_backup is not None:
+            with open_irodsa(DEFAULT_IRODSA_PATH, "w", encoding="utf-8") as handle:
+                handle.write(irodsa_backup)
+    except KeyError:
+        ienv_path = ienv_path_or_alias
+        cwd = cwd
+
+    return Session(ienv_path, *args, **kwargs, cwd=cwd_final)
+
+
+def interactive_auth(
+    password: Optional[str] = None, irods_env_path: Union[None, str, Path] = None,
+    irodsa_backup: Optional[str] = None,
+    **kwargs
+) -> Session:
+    """Interactive authentication with iRODS server.
+
+    The main difference with using the :class:`ibridges.Session` object directly is
+    that it will ask for your password if the cached password does not exist or is outdated.
+    This can be more secure, since you won't have to store the password in a file or notebook.
+    Caches the password in ~/.irods/.irodsA upon success.
+
+    Parameters
+    ----------
+    password:
+        Password to make the connection with. If not supplied, you will be asked interactively.
+    irods_env_path:
+        Path to the irods environment.
+    irodsa_backup:
+        Backup of the .irodsA file to be used in case authentication fails.
+    kwargs:
+        Extra parameters for the interactive auth. Mainly used for the cwd parameter.
+
+    Raises
+    ------
+    FileNotFoundError:
+        If the irods_env_path does not exist.
+    ValueError:
+        If the connection to the iRods server cannot be established.
+
+    Returns
+    -------
+        A connected session to the server.
+
+    """
+    if irods_env_path is None:
+        irods_env_path = DEFAULT_IENV_PATH
+    if not os.path.exists(irods_env_path):
+        print(f"File not found: {irods_env_path}")
+        raise FileNotFoundError
+
+    session = None
+    if DEFAULT_IRODSA_PATH.is_file() and password is None:
+        session = _from_pw_file(irods_env_path, irodsa_backup=irodsa_backup, **kwargs)
+
+    if password is not None:
+        session = _from_password(irods_env_path, password, **kwargs)
+
+    if session is not None:
+        return session
+
+    # If provided passwords in file or on prompt were wrong
+    n_tries = 0
+    success = False
+    while not success and n_tries < 3:
+        if sys.stdin.isatty() or 'ipykernel' in sys.modules:
+            password = getpass('Your iRODS password: ')
+        else:
+            print('Your iRODS password: ')
+            password = sys.stdin.readline().rstrip()
+        try:
+            session = Session(irods_env=irods_env_path, password=password, **kwargs)
+            session.write_pam_password()
+            success = True
+            return session
+        except PasswordError as e:
+            print(repr(e))
+            print("INFO: The provided username and/or password is wrong.")
+            n_tries += 1
+    raise LoginError("Connection to iRODS could not be established.")
+
+
+def _from_pw_file(irods_env_path, irodsa_backup: Optional[str] = None, **kwargs):
+    try:
+        session = Session(irods_env_path, **kwargs)
+        return session
+    except IndexError:
+        print("INFO: The cached password in ~/.irods/.irodsA has been corrupted")
+    except PasswordError:
+        if irodsa_backup is not None:
+            with open_irodsa(DEFAULT_IRODSA_PATH, "w", encoding="utf-8") as handle:
+                handle.write(irodsa_backup)
+            try:
+                session = Session(irods_env_path, **kwargs)
+                return session
+            except PasswordError:
+                print("INFO: The cached password in ~/.irods/.irodsA is wrong.")
+    return None
+
+
+def _from_password(irods_env_path, password, **kwargs):
+    try:
+        session = Session(irods_env=irods_env_path, password=password, **kwargs)
+        session.write_pam_password()
+        return session
+    except PasswordError:
+        print("INFO: The provided username and/or password is wrong.")
+    return None

--- a/ibridges/authenticate.py
+++ b/ibridges/authenticate.py
@@ -52,8 +52,12 @@ def non_interactive_auth(*args, ienv_path_or_alias: Optional[str] = None,
     parser:
         Parser to relay the error messages to. By default, errors are raised as
         ValueError's.
+    reauthenticate:
+        If reauthenticate is set to True, then cached passwords will be ignored and a new password
+        can be submitted.
     kwargs:
         Extra keyword arguments for the session such as home and password.
+
 
     Returns
     -------

--- a/ibridges/authenticate.py
+++ b/ibridges/authenticate.py
@@ -63,6 +63,7 @@ def non_interactive_auth(*args, ienv_path_or_alias: Optional[str] = None,
     """
     # iBridges doesn't have a non-interactive auth, so make one.
     ibridges_conf = IbridgesConf(parser=parser)
+    ienv_path: Optional[str]
     try:
         ienv_path, ienv_entry = ibridges_conf.get_entry(ienv_path_or_alias)
         irodsa_backup = ienv_entry.get("irodsa_backup", None)
@@ -74,8 +75,10 @@ def non_interactive_auth(*args, ienv_path_or_alias: Optional[str] = None,
     except KeyError:
         ienv_path = ienv_path_or_alias
         cwd_final = cwd
+    if ienv_path is None:
+        raise ValueError("Could not find specified irods environment.")
 
-    return Session(ienv_path, *args, **kwargs, cwd=cwd_final)
+    return Session(ienv_path, *args, cwd=cwd_final, **kwargs)  # type: ignore
 
 
 def interactive_auth(

--- a/ibridges/cli/base.py
+++ b/ibridges/cli/base.py
@@ -6,7 +6,7 @@ import abc
 import argparse
 from abc import abstractmethod
 
-from ibridges.cli.util import cli_authenticate
+from ibridges.authenticate import cli_auth
 
 
 class ShellArgumentParser(argparse.ArgumentParser):
@@ -107,7 +107,7 @@ class BaseCliCommand(abc.ABC):
 
         """
         parser = cls.get_parser(argparse.ArgumentParser)
-        with cli_authenticate(parser) as session:
+        with cli_auth(parser) as session:
             cls.run_shell(session, parser, args)
 
     @classmethod

--- a/ibridges/cli/config.py
+++ b/ibridges/cli/config.py
@@ -7,7 +7,7 @@ import warnings
 from pathlib import Path
 from typing import Union
 
-from ibridges.util import ValueErrorParser, open_irodsa, DEFAULT_IENV_PATH, DEFAULT_IRODSA_PATH
+from ibridges.util import DEFAULT_IENV_PATH, DEFAULT_IRODSA_PATH, ValueErrorParser, open_irodsa
 
 IBRIDGES_CONFIG_FP = Path.home() / ".ibridges" / "ibridges_cli.json"
 

--- a/ibridges/cli/config.py
+++ b/ibridges/cli/config.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Union
 
 from ibridges.interactive import DEFAULT_IENV_PATH, DEFAULT_IRODSA_PATH
+from ibridges.util import ValueErrorParser, open_irodsa
 
 IBRIDGES_CONFIG_FP = Path.home() / ".ibridges" / "ibridges_cli.json"
 
@@ -15,7 +16,8 @@ IBRIDGES_CONFIG_FP = Path.home() / ".ibridges" / "ibridges_cli.json"
 class IbridgesConf():
     """Interface to the iBridges configuration file class."""
 
-    def __init__(self, parser: argparse.ArgumentParser,
+    def __init__(self,
+                 parser: Union[argparse.ArgumentParser, ValueErrorParser] = ValueErrorParser(),
                  config_fp: Union[str, Path]=IBRIDGES_CONFIG_FP):
         """Read configuration file and validate it.
 
@@ -174,7 +176,7 @@ class IbridgesConf():
             self.cur_env = ienv_path
             ienv_entry = self.servers[ienv_path]
             if "irodsa_backup" in ienv_entry:
-                with open(DEFAULT_IRODSA_PATH, "w", encoding="utf-8") as handle:
+                with open_irodsa(DEFAULT_IRODSA_PATH, "w", encoding="utf-8") as handle:
                     handle.write(ienv_entry["irodsa_backup"])
             self.save()
 

--- a/ibridges/cli/config.py
+++ b/ibridges/cli/config.py
@@ -7,8 +7,7 @@ import warnings
 from pathlib import Path
 from typing import Union
 
-from ibridges.interactive import DEFAULT_IENV_PATH, DEFAULT_IRODSA_PATH
-from ibridges.util import ValueErrorParser, open_irodsa
+from ibridges.util import ValueErrorParser, open_irodsa, DEFAULT_IENV_PATH, DEFAULT_IRODSA_PATH
 
 IBRIDGES_CONFIG_FP = Path.home() / ".ibridges" / "ibridges_cli.json"
 

--- a/ibridges/cli/navigation.py
+++ b/ibridges/cli/navigation.py
@@ -10,9 +10,10 @@ import unicodedata
 from importlib.metadata import version
 from typing import Optional
 
+from ibridges.authenticate import cli_auth
 from ibridges.cli.base import BaseCliCommand
 from ibridges.cli.config import IbridgesConf
-from ibridges.cli.util import cli_authenticate, list_collection, parse_remote
+from ibridges.cli.util import list_collection, parse_remote
 from ibridges.exception import CollectionDoesNotExistError, NotACollectionError
 from ibridges.path import IrodsPath
 from ibridges.search import search_data
@@ -170,7 +171,7 @@ class CliCd(BaseCliCommand):
     def run_command(cls, args):
         """Change collection in the cli."""
         parser = cls.get_parser(argparse.ArgumentParser)
-        with cli_authenticate(parser) as session:
+        with cli_auth(parser) as session:
             new_ipath = parse_remote(args.remote_coll, session)
             if not new_ipath.collection_exists():
                 parser.error(f"Collection {new_ipath} does not exist.")

--- a/ibridges/cli/other.py
+++ b/ibridges/cli/other.py
@@ -5,13 +5,13 @@ import time
 import traceback
 from pathlib import Path
 
+from ibridges.authenticate import cli_auth
 from ibridges.cli.base import BaseCliCommand
 from ibridges.cli.config import IbridgesConf
 from ibridges.cli.shell import IBridgesShell
-from ibridges.cli.util import cli_authenticate
-from ibridges.util import DEFAULT_IENV_PATH
 from ibridges.session import Session
 from ibridges.util import (
+    DEFAULT_IENV_PATH,
     find_environment_provider,
     get_environment_providers,
     print_environment_providers,
@@ -138,7 +138,7 @@ class CliInit(BaseCliCommand):
         parser = cls.get_parser(argparse.ArgumentParser)
         IbridgesConf(parser).set_env(args.irods_env_path_or_alias)
 
-        with cli_authenticate(parser) as session:
+        with cli_auth(parser) as session:
             if not isinstance(session, Session):
                 parser.error(f"Irods session '{session}' is not a session.")
         print("ibridges init was succesful.")

--- a/ibridges/cli/other.py
+++ b/ibridges/cli/other.py
@@ -125,6 +125,11 @@ class CliInit(BaseCliCommand):
             default=None,
             nargs="?",
         )
+        parser.add_argument(
+            "--reauthenticate",
+            help="If you want to update your password while the old one still works.",
+            action="store_true"
+        )
         return parser
 
     @staticmethod
@@ -138,7 +143,7 @@ class CliInit(BaseCliCommand):
         parser = cls.get_parser(argparse.ArgumentParser)
         IbridgesConf(parser).set_env(args.irods_env_path_or_alias)
 
-        with cli_auth(parser) as session:
+        with cli_auth(parser, args.reauthenticate) as session:
             if not isinstance(session, Session):
                 parser.error(f"Irods session '{session}' is not a session.")
         print("ibridges init was succesful.")

--- a/ibridges/cli/other.py
+++ b/ibridges/cli/other.py
@@ -9,7 +9,7 @@ from ibridges.cli.base import BaseCliCommand
 from ibridges.cli.config import IbridgesConf
 from ibridges.cli.shell import IBridgesShell
 from ibridges.cli.util import cli_authenticate
-from ibridges.interactive import DEFAULT_IENV_PATH
+from ibridges.util import DEFAULT_IENV_PATH
 from ibridges.session import Session
 from ibridges.util import (
     find_environment_provider,

--- a/ibridges/cli/shell.py
+++ b/ibridges/cli/shell.py
@@ -12,10 +12,10 @@ try:
 except ImportError:
     from importlib.metadata import entry_points  # type: ignore
 
+from ibridges.authenticate import cli_auth
 from ibridges.cli.data_operations import CliDownload, CliMakeCollection, CliRm, CliSync, CliUpload
 from ibridges.cli.meta import CliMetaAdd, CliMetaDel, CliMetaList
 from ibridges.cli.navigation import CliCd, CliGui, CliList, CliPwd, CliSearch, CliTree, CliVersion
-from ibridges.cli.util import cli_authenticate
 from ibridges.path import IrodsPath
 
 ALL_BUILTIN_COMMANDS = [
@@ -55,7 +55,7 @@ class IBridgesShell(cmd.Cmd):
             readline.set_history_length(1000)
         except ImportError:
             pass
-        self.session = cli_authenticate(None)
+        self.session = cli_auth(None)
         self.commands = {}
         for command_class in get_all_shell_commands():
             for name in command_class.names:

--- a/ibridges/cli/util.py
+++ b/ibridges/cli/util.py
@@ -1,33 +1,20 @@
 """Utilities for the CLI and shell."""
-from pathlib import Path
+import warnings
 from typing import Union
 
-from ibridges.cli.config import IbridgesConf
+from ibridges.authenticate import cli_auth
 from ibridges.exception import NotACollectionError
-from ibridges.interactive import DEFAULT_IRODSA_PATH, interactive_auth
 from ibridges.path import IrodsPath
 from ibridges.session import Session
 from ibridges.util import get_collection
 
 
 def cli_authenticate(parser):
-    """Authenticate for the CLI and shell."""
-    ibridges_conf = IbridgesConf(parser)
-    ienv_path, ienv_entry = ibridges_conf.get_entry()
-    ienv_cwd = ienv_entry.get("cwd", None)
+    """Authenticate with cli authentication."""
+    warnings.warn("ibridges.cli.cli_authenticate() is deprecated, "
+                  "use ibridges.authenticate.cli_auth() instead.")
+    return cli_auth(parser)
 
-    if not Path(ienv_path).exists():
-        parser.error(f"Error: Irods environment file or alias '{ienv_path}' does not exist.")
-    session = interactive_auth(irods_env_path=ienv_path, cwd=ienv_cwd,
-                               irodsa_backup=ienv_entry.get("irodsa_backup", None))
-
-    with open(DEFAULT_IRODSA_PATH, "r", encoding="utf-8") as handle:
-        irodsa_content = handle.read()
-    if irodsa_content != ienv_entry.get("irodsa_backup"):
-        ienv_entry["irodsa_backup"] = irodsa_content
-        ibridges_conf.save()
-
-    return session
 
 def list_collection(session: Session, remote_path: IrodsPath, metadata: bool = False):
     """List a collection with default formatting."""

--- a/ibridges/interactive.py
+++ b/ibridges/interactive.py
@@ -1,112 +1,16 @@
-"""Interactive authentication with iRODS server."""
+"""Deprecated module with interactive elements."""
 
-import os
-import sys
-from getpass import getpass
-from pathlib import Path
-from typing import Optional, Union
+import warnings
 
-from ibridges.session import LoginError, PasswordError, Session
-
-DEFAULT_IENV_PATH = Path(os.path.expanduser("~")).joinpath(".irods", "irods_environment.json")
-DEFAULT_IRODSA_PATH = Path.home() / ".irods" / ".irodsA"
+from ibridges.authenticate import interactive_auth as iauth
 
 
-def interactive_auth(
-    password: Optional[str] = None, irods_env_path: Union[None, str, Path] = None,
-    irodsa_backup: Optional[str] = None,
-    **kwargs
-) -> Session:
-    """Interactive authentication with iRODS server.
+def interactive_auth(*args, **kwargs):
+    """Authenticate interactively.
 
-    The main difference with using the :class:`ibridges.Session` object directly is
-    that it will ask for your password if the cached password does not exist or is outdated.
-    This can be more secure, since you won't have to store the password in a file or notebook.
-    Caches the password in ~/.irods/.irodsA upon success.
-
-    Parameters
-    ----------
-    password:
-        Password to make the connection with. If not supplied, you will be asked interactively.
-    irods_env_path:
-        Path to the irods environment.
-    irodsa_backup:
-        Backup of the .irodsA file to be used in case authentication fails.
-    kwargs:
-        Extra parameters for the interactive auth. Mainly used for the cwd parameter.
-
-    Raises
-    ------
-    FileNotFoundError:
-        If the irods_env_path does not exist.
-    ValueError:
-        If the connection to the iRods server cannot be established.
-
-    Returns
-    -------
-        A connected session to the server.
-
+    This function has been moved to ibridges.authenticate.
     """
-    if irods_env_path is None:
-        irods_env_path = DEFAULT_IENV_PATH
-    if not os.path.exists(irods_env_path):
-        print(f"File not found: {irods_env_path}")
-        raise FileNotFoundError
-
-    session = None
-    if DEFAULT_IRODSA_PATH.is_file() and password is None:
-        session = _from_pw_file(irods_env_path, irodsa_backup=irodsa_backup, **kwargs)
-
-    if password is not None:
-        session = _from_password(irods_env_path, password, **kwargs)
-
-    if session is not None:
-        return session
-
-    # If provided passwords in file or on prompt were wrong
-    n_tries = 0
-    success = False
-    while not success and n_tries < 3:
-        if sys.stdin.isatty() or 'ipykernel' in sys.modules:
-            password = getpass('Your iRODS password: ')
-        else:
-            print('Your iRODS password: ')
-            password = sys.stdin.readline().rstrip()
-        try:
-            session = Session(irods_env=irods_env_path, password=password, **kwargs)
-            session.write_pam_password()
-            success = True
-            return session
-        except PasswordError as e:
-            print(repr(e))
-            print("INFO: The provided username and/or password is wrong.")
-            n_tries += 1
-    raise LoginError("Connection to iRODS could not be established.")
-
-
-def _from_pw_file(irods_env_path, irodsa_backup: Optional[str] = None, **kwargs):
-    try:
-        session = Session(irods_env_path, **kwargs)
-        return session
-    except IndexError:
-        print("INFO: The cached password in ~/.irods/.irodsA has been corrupted")
-    except PasswordError:
-        if irodsa_backup is not None:
-            with open(DEFAULT_IRODSA_PATH, "w", encoding="utf-8") as handle:
-                handle.write(irodsa_backup)
-            try:
-                session = Session(irods_env_path, **kwargs)
-                return session
-            except PasswordError:
-                print("INFO: The cached password in ~/.irods/.irodsA is wrong.")
-    return None
-
-
-def _from_password(irods_env_path, password, **kwargs):
-    try:
-        session = Session(irods_env=irods_env_path, password=password, **kwargs)
-        session.write_pam_password()
-        return session
-    except PasswordError:
-        print("INFO: The provided username and/or password is wrong.")
-    return None
+    warnings.warn("ibridges.interactive.interactive_auth() has been moved, "
+                  "use ibridges.authenticate.interactive_auth instead.",
+                  DeprecationWarning)
+    return iauth(*args, **kwargs)

--- a/ibridges/session.py
+++ b/ibridges/session.py
@@ -21,6 +21,7 @@ from irods.exception import (
 from irods.session import NonAnonymousLoginWithoutPassword, iRODSSession
 
 from ibridges import icat_columns as icat
+from ibridges.util import open_irodsa
 
 APP_NAME = "ibridges"
 
@@ -333,7 +334,7 @@ class Session:  # pylint: disable=too-many-instance-attributes
             irods_auth_file = self.irods_session.get_irods_password_file()
             if not Path(irods_auth_file).parent.exists():
                 Path(irods_auth_file).parent.mkdir(parents=True)
-            with open(irods_auth_file, "w", encoding="utf-8") as authfd:
+            with open_irodsa(irods_auth_file, "w", encoding="utf-8") as authfd:
                 authfd.write(irods.password_obfuscation.encode(actual_password))
         else:
             warnings.warn("WARNING -- unable to cache obfuscated password locally")

--- a/ibridges/util.py
+++ b/ibridges/util.py
@@ -14,6 +14,9 @@ import irods
 
 from ibridges.path import IrodsPath
 
+DEFAULT_IENV_PATH = Path.home() / ".irods" / "irods_environment.json"
+DEFAULT_IRODSA_PATH = Path.home() / ".irods" / ".irodsA"
+
 try:
     from importlib_metadata import entry_points
 except ImportError:

--- a/ibridges/util.py
+++ b/ibridges/util.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import base64
+import contextlib
+import os
 from collections.abc import Sequence
 from hashlib import md5, sha256
 from pathlib import Path
@@ -209,3 +211,32 @@ def checksums_equal(remote_path: IrodsPath, local_path: Union[Path, str]):
     remote_check = calc_checksum(remote_path)
     local_check = calc_checksum(local_path, checksum_type=_detect_checksum(remote_check))
     return remote_check == local_check
+
+
+class ValueErrorParser():
+    """For raising value errors instead of ArgumentParser errors.
+
+    IbridgesConf is a class normally used for the command line interface (CLI).
+    This ensures that errors normally passed to the argument parser, will be raised as ValueErrors
+    instead.
+
+    """
+
+    def error(self, msg: str):
+        """Raise error message."""
+        raise ValueError(msg)
+
+# Copied from python-irodsclient: client_init.py f700ab5
+@contextlib.contextmanager
+def open_irodsa(file_path, *arg, **kw):
+    """Open a file with 0o600 file permissions generally."""
+    f = old_mask = None
+    try:
+        old_mask = os.umask(0o77)
+        f = open(file_path, *arg, **kw)
+        yield f
+    finally:
+        if old_mask is not None:
+            os.umask(old_mask)
+        if f is not None:
+            f.close()

--- a/ibridges/util.py
+++ b/ibridges/util.py
@@ -216,7 +216,7 @@ def checksums_equal(remote_path: IrodsPath, local_path: Union[Path, str]):
     return remote_check == local_check
 
 
-class ValueErrorParser():
+class ValueErrorParser():  # pylint: disable=too-few-public-methods
     """For raising value errors instead of ArgumentParser errors.
 
     IbridgesConf is a class normally used for the command line interface (CLI).
@@ -236,7 +236,7 @@ def open_irodsa(file_path, *arg, **kw):
     f = old_mask = None
     try:
         old_mask = os.umask(0o77)
-        f = open(file_path, *arg, **kw)
+        f = open(file_path, *arg, **kw)  # pylint: disable=unspecified-encoding
         yield f
     finally:
         if old_mask is not None:


### PR DESCRIPTION
Fixes #376, fixes #377 also adds ability to reauthenticate even if the current password still works with a new flag for the init:

`ibridges init --reauthenticate`